### PR TITLE
1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+TODOs
+=======
+
+* extract_entities is better named as extract_models 
+
+* add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity()
+
+* 
+
+
+
 Changelog
 =======
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Changelog
 
 Summary of changes. 
 
+March 21, 2018: v1.8.8
+---------------------------------
+* fix https://github.com/lambdamusic/Ontospy/issues/33
+* instances method for classes on-demand
+* simplified describe method
+* cli: no args shows help
+* fix reference to ontodocs
+* Merge pull request #37 from satra/patch-1
+
 
 June 1, 2017
 ---------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,3 @@
-TODOs
-=======
-
-* extract_entities is better named as extract_models 
-
-* add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity()
-
-* 
-
-
-
 Changelog
 =======
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ Changelog
 
 Summary of changes. 
 
+
+May 9, 2018: v1.9
+---------------------------------
+Refactoring method names:
+* all 'extract_' methods renamed as 'build_' renamed as extract_all 
+* build_entity_from_uri: extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further  
+* x.rdfgraph renamed as x.rdflib_graph 
+* x.serialize renamed as x.rdf_source
+* tidy up all tests code
+* ontospy properties returning entities: all renamed using the all_* pattern eg all_classes etc..
+
+
+
 March 21, 2018: v1.8.8
 ---------------------------------
 * fix https://github.com/lambdamusic/Ontospy/issues/33

--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,13 @@ TODOs
 
 * extract_entity_from_uri: add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further  @DONE
 
-* x.rdfgraph should be x.rdflib_graph
+* x.rdfgraph should be x.rdflib_graph   @DONE
+
+* x.serialize better named as x.rdf_source(...)
 
 * x.properties => x.properties_all
 * x.annotationProperties  => x.properties_annotation
 etc..etc... (ONTODOCS dependency here though)
 
-* x.serialize better named as x.rdf_source(...)
 
 * tidy up all tests code and rationale

--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,8 @@ TODOs
 * tidy up all tests code and rationale @DONE
 
 
-* x.properties => x.properties_all
-* x.annotationProperties  => x.properties_annotation
+* x.properties => x.all_properties
+* x.annotationProperties  => x.all_properties_annotation
 etc..etc... (ONTODOCS dependency here though)
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@ TODOs
 * tidy up all tests code and rationale @DONE
 
 
+* rename all entities methods @DONE
 * x.all_properties => x.all_properties
 * x.annotationProperties  => x.all_properties_annotation
 etc..etc... (ONTODOCS dependency here though)

--- a/TODO.md
+++ b/TODO.md
@@ -1,22 +1,4 @@
 TODOs
 =======
 
-* extract_entities is better named as extract_all @DONE
-
-* extract_entity_from_uri: add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further  @DONE
-
-* x.rdfgraph should be x.rdflib_graph   @DONE
-
-* x.serialize better named as x.rdf_source(...) @DONE
-
-* tidy up all tests code and rationale @DONE
-
-
-* rename all entities methods @DONE
-* x.all_properties => x.all_properties
-* x.annotationProperties  => x.all_properties_annotation
-etc..etc... (ONTODOCS dependency here though)
-
-
-
-* before making a release, check that ontodocs doesn't break
+* ....

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@ TODOs
 
 * extract_entities is better named as extract_all @DONE
 
-* extract_entity_from_uri: add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further 
+* extract_entity_from_uri: add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further  @DONE
 
 * x.rdfgraph should be x.rdflib_graph
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,15 @@ TODOs
 
 * x.rdfgraph should be x.rdflib_graph   @DONE
 
-* x.serialize better named as x.rdf_source(...)
+* x.serialize better named as x.rdf_source(...) @DONE
+
+* tidy up all tests code and rationale @DONE
+
 
 * x.properties => x.properties_all
 * x.annotationProperties  => x.properties_annotation
 etc..etc... (ONTODOCS dependency here though)
 
 
-* tidy up all tests code and rationale
+
+* before making a release, check that ontodocs doesn't break

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 TODOs
 =======
 
-* extract_entities is better named as extract_all 
+* extract_entities is better named as extract_all @DONE
 
 * extract_entity_from_uri: add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further 
 
@@ -13,3 +13,4 @@ etc..etc... (ONTODOCS dependency here though)
 
 * x.serialize better named as x.rdf_source(...)
 
+* tidy up all tests code and rationale

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+TODOs
+=======
+
+* extract_entities is better named as extract_models 
+
+* add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity()
+
+* 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,12 @@
 TODOs
 =======
 
-* extract_entities is better named as extract_models 
+* extract_entities is better named as extract_all 
 
-* add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity()
+* extract_entity_from_uri: add a method to extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further 
 
-* 
+* x.rdfgraph should be x.rdflib_graph
+
+* x.properties => x.properties_all
+* x.annotationProperties  => x.properties_annotation
+etc..etc... (ONTODOCS dependency here though)

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ TODOs
 * tidy up all tests code and rationale @DONE
 
 
-* x.properties => x.all_properties
+* x.all_properties => x.all_properties
 * x.annotationProperties  => x.all_properties_annotation
 etc..etc... (ONTODOCS dependency here though)
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,3 +10,6 @@ TODOs
 * x.properties => x.properties_all
 * x.annotationProperties  => x.properties_annotation
 etc..etc... (ONTODOCS dependency here though)
+
+* x.serialize better named as x.rdf_source(...)
+

--- a/ontospy/VERSION.py
+++ b/ontospy/VERSION.py
@@ -11,7 +11,7 @@
 
 
 
-__version__ = "1.8.8"  # 2018-03-21
+__version__ = "1.9"  # 2018-05-08
 
 __copyright__ = "CopyRight (C) 2015-2018 by Michele Pasin"
 __license__ = "GNU"

--- a/ontospy/core/actions.py
+++ b/ontospy/core/actions.py
@@ -326,7 +326,7 @@ def _import_PREFIXCC(keyword=""):
     printDebug("----------\nReading source...")
     g = Ontospy(SOURCE, verbose=False)
 
-    for x in g.ontologies:
+    for x in g.all_ontologies:
         if keyword:
             if keyword in unicode(x.prefix).lower() or keyword in unicode(x.uri).lower():
                 options += [(unicode(x.prefix), unicode(x.uri))]

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -63,7 +63,7 @@ class RDF_Entity(object):
         self._parents = []
         # self.siblings = []
 
-    def serialize(self, format="turtle"):
+    def rdf_source(self, format="turtle"):
         """ xml, n3, turtle, nt, pretty-xml, trix are built in"""
         if self.triples:
             if not self.rdflib_graph:
@@ -73,7 +73,7 @@ class RDF_Entity(object):
             return None
 
     def printSerialize(self, format="turtle"):
-        printDebug("\n" + self.serialize(format))
+        printDebug("\n" + self.rdf_source(format))
 
     def printTriples(self):
         """ display triples """

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -230,7 +230,7 @@ class Ontology(RDF_Entity):
         self.prefix = prefPrefix
         self.slug = "ontology-" + slugify(self.qname)
         self.all_classes = []
-        self.properties = []
+        self.all_properties = []
         self.skosConcepts = []
 
     def annotations(self, qname=True):
@@ -254,7 +254,7 @@ class Ontology(RDF_Entity):
     def stats(self):
         """ shotcut to pull out useful info for interactive use """
         printDebug("Classes.....: %d" % len(self.all_classes))
-        printDebug("Properties..: %d" % len(self.properties))
+        printDebug("Properties..: %d" % len(self.all_properties))
 
 
 

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -52,7 +52,7 @@ class RDF_Entity(object):
         self.slug	 = None
         self.rdftype = rdftype
         self.triples = None
-        self.rdfgraph = rdflib.Graph()
+        self.rdflib_graph = rdflib.Graph()
         self.namespaces = namespaces
         self.shapes = []
 
@@ -66,9 +66,9 @@ class RDF_Entity(object):
     def serialize(self, format="turtle"):
         """ xml, n3, turtle, nt, pretty-xml, trix are built in"""
         if self.triples:
-            if not self.rdfgraph:
+            if not self.rdflib_graph:
                 self._buildGraph()
-            return self.rdfgraph.serialize(format=format)
+            return self.rdflib_graph.serialize(format=format)
         else:
             return None
 
@@ -98,10 +98,10 @@ class RDF_Entity(object):
         (which can be used later for querying)
         """
         for n in self.namespaces:
-            self.rdfgraph.bind(n[0], rdflib.Namespace(n[1]))
+            self.rdflib_graph.bind(n[0], rdflib.Namespace(n[1]))
         if self.triples:
             for terzetto in self.triples:
-                self.rdfgraph.add(terzetto)
+                self.rdflib_graph.add(terzetto)
 
     # methods added to RDF_Entity even though they apply only to some subs
 
@@ -163,7 +163,7 @@ class RDF_Entity(object):
         """
         if not type(aPropURIRef) == rdflib.URIRef:
             aPropURIRef = rdflib.URIRef(aPropURIRef)
-        return list(self.rdfgraph.objects(None, aPropURIRef))
+        return list(self.rdflib_graph.objects(None, aPropURIRef))
 
 
     def bestLabel(self, prefLanguage="en", qname_allowed=True, quotes=False):

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -54,7 +54,7 @@ class RDF_Entity(object):
         self.triples = None
         self.rdflib_graph = rdflib.Graph()
         self.namespaces = namespaces
-        self.shapes = []
+        self.all_shapes = []
 
         self.qname = self._build_qname()
         self.rdftype_qname = self._build_qname(rdftype)
@@ -231,7 +231,7 @@ class Ontology(RDF_Entity):
         self.slug = "ontology-" + slugify(self.qname)
         self.all_classes = []
         self.all_properties = []
-        self.skosConcepts = []
+        self.all_skos_concepts = []
 
     def annotations(self, qname=True):
         """

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -157,6 +157,8 @@ class RDF_Entity(object):
             [rdflib.term.URIRef(u'http://www.w3.org/2002/07/owl#Class'),
              rdflib.term.URIRef(u'http://www.w3.org/2000/01/rdf-schema#Class')]
         """
+        if not type(aPropURIRef) == rdflib.URIRef:
+            aPropURIRef = rdflib.URIRef(aPropURIRef)
         return list(self.rdfgraph.objects(None, aPropURIRef))
 
 

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -45,17 +45,19 @@ class RDF_Entity(object):
         self.id = next(self._ids)
 
         self.uri = uri # rdflib.Uriref
-        self.qname = self.__buildQname(self.uri, namespaces)
+
         self.locale	 = inferURILocalSymbol(self.uri)[0]
         self.ext_model = ext_model
         self.is_Bnode = is_Bnode
         self.slug	 = None
         self.rdftype = rdftype
-        self.rdftype_qname = self.__buildQname(rdftype, namespaces)
         self.triples = None
         self.rdfgraph = rdflib.Graph()
         self.namespaces = namespaces
         self.shapes = []
+
+        self.qname = self._build_qname()
+        self.rdftype_qname = self._build_qname(rdftype)
 
         self._children = []
         self._parents = []
@@ -81,12 +83,14 @@ class RDF_Entity(object):
             printDebug(Fore.GREEN + ".... " + unicode(x[2]) + Fore.RESET)
         print("")
 
-    def __buildQname(self, uri, namespaces, ):
+    def _build_qname(self, uri=None, namespaces=None ):
         """ extracts a qualified name for a uri """
-        if uri:
-            return uri2niceString(uri, namespaces)
-        else:
-            return ""
+        if not uri:
+            uri = self.uri
+        if not namespaces:
+            namespaces = self.namespaces
+        return uri2niceString(uri, namespaces)
+
 
     def _buildGraph(self):
         """

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -229,7 +229,7 @@ class Ontology(RDF_Entity):
         # self.uri = uri # rdflib.Uriref
         self.prefix = prefPrefix
         self.slug = "ontology-" + slugify(self.qname)
-        self.classes = []
+        self.all_classes = []
         self.properties = []
         self.skosConcepts = []
 
@@ -253,7 +253,7 @@ class Ontology(RDF_Entity):
 
     def stats(self):
         """ shotcut to pull out useful info for interactive use """
-        printDebug("Classes.....: %d" % len(self.classes))
+        printDebug("Classes.....: %d" % len(self.all_classes))
         printDebug("Properties..: %d" % len(self.properties))
 
 

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -298,7 +298,7 @@ class OntoClass(RDF_Entity):
             # calculate and set
             self._instances = []
             if self.sparqlHelper:
-                qres = self.sparqlHelper.getClassInstances(self.uri)
+                qres = self.sparqlHelper.get_classInstances(self.uri)
                 for uri in [x[0] for x in qres]:
                     instance = RDF_Entity(uri, self.uri, self.namespaces)
                     instance.triples = self.sparqlHelper.entityTriples(instance.uri)
@@ -314,7 +314,7 @@ class OntoClass(RDF_Entity):
     def count(self):
         return len(self.instances)
         # if self.sparqlHelper:
-        #     return self.sparqlHelper.getClassInstancesCount(self.uri)
+        #     return self.sparqlHelper.get_classInstancesCount(self.uri)
         # else:
         #     return 0
 

--- a/ontospy/core/entities.py
+++ b/ontospy/core/entities.py
@@ -298,7 +298,7 @@ class OntoClass(RDF_Entity):
             # calculate and set
             self._instances = []
             if self.sparqlHelper:
-                qres = self.sparqlHelper.get_classInstances(self.uri)
+                qres = self.sparqlHelper.getClassInstances(self.uri)
                 for uri in [x[0] for x in qres]:
                     instance = RDF_Entity(uri, self.uri, self.namespaces)
                     instance.triples = self.sparqlHelper.entityTriples(instance.uri)
@@ -313,10 +313,6 @@ class OntoClass(RDF_Entity):
 
     def count(self):
         return len(self.instances)
-        # if self.sparqlHelper:
-        #     return self.sparqlHelper.get_classInstancesCount(self.uri)
-        # else:
-        #     return 0
 
 
     def printStats(self):

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -280,7 +280,7 @@ class Ontospy(object):
             except:
                 _type= ""
 
-            test_existing_cl = self.getClass(uri=_uri)
+            test_existing_cl = self.get_class(uri=_uri)
             if not test_existing_cl:
                 # create it
                 ontoclass = OntoClass(_uri, _type, self.namespaces)
@@ -300,16 +300,16 @@ class Ontospy(object):
 
             # attach to an ontology
             for uri in aClass.getValuesForProperty(rdflib.RDFS.isDefinedBy):
-                onto = self.getOntology(str(uri))
+                onto = self.get_ontology(str(uri))
                 if onto:
                     onto.all_classes += [aClass]
                     aClass.ontology = onto
 
             # add direct Supers
-            directSupers = self.sparqlHelper.getClassDirectSupers(aClass.uri)
+            directSupers = self.sparqlHelper.get_classDirectSupers(aClass.uri)
 
             for x in directSupers:
-                superclass = self.getClass(uri=x[0])
+                superclass = self.get_class(uri=x[0])
                 # note: extra condition to avoid recursive structures
                 if superclass and superclass.uri != aClass.uri:
                     aClass._parents.append(superclass)
@@ -350,7 +350,7 @@ class Ontospy(object):
 
         for candidate in qres:
 
-            test_existing_prop = self.getProperty(uri=candidate[0])
+            test_existing_prop = self.get_property(uri=candidate[0])
             if not test_existing_prop:
                 # create it
                 self.all_properties += [OntoProperty(candidate[0], candidate[1], self.namespaces)]
@@ -377,7 +377,7 @@ class Ontospy(object):
 
             # attach to an ontology [2015-06-15: no property type distinction yet]
             for uri in aProp.getValuesForProperty(rdflib.RDFS.isDefinedBy):
-                onto = self.getOntology(str(uri))
+                onto = self.get_ontology(str(uri))
                 if onto:
                     onto.all_properties += [aProp]
                     aProp.ontology = onto
@@ -390,7 +390,7 @@ class Ontospy(object):
             directSupers = self.sparqlHelper.getPropDirectSupers(aProp.uri)
 
             for x in directSupers:
-                superprop = self.getProperty(uri=x[0])
+                superprop = self.get_property(uri=x[0])
                 # note: extra condition to avoid recursive structures
                 if superprop and superprop.uri != aProp.uri:
                     aProp._parents.append(superprop)
@@ -423,7 +423,7 @@ class Ontospy(object):
 
         for candidate in qres:
 
-            test_existing_cl = self.getSkosConcept(uri=candidate[0])
+            test_existing_cl = self.get_skos(uri=candidate[0])
             if not test_existing_cl:
                 # create it
                 self.all_skos_concepts += [OntoSKOSConcept(candidate[0], None, self.namespaces)]
@@ -443,7 +443,7 @@ class Ontospy(object):
 
             # attach to an ontology
             for uri in aConcept.getValuesForProperty(rdflib.RDFS.isDefinedBy):
-                onto = self.getOntology(str(uri))
+                onto = self.get_ontology(str(uri))
                 if onto:
                     onto.all_skos_concepts += [aConcept]
                     aConcept.ontology = onto
@@ -452,7 +452,7 @@ class Ontospy(object):
             directSupers = self.sparqlHelper.getSKOSDirectSupers(aConcept.uri)
 
             for x in directSupers:
-                superclass = self.getSkosConcept(uri=x[0])
+                superclass = self.get_skos(uri=x[0])
                 # note: extra condition to avoid recursive structures
                 if superclass and superclass.uri != aConcept.uri:
                     aConcept._parents.append(superclass)
@@ -489,7 +489,7 @@ class Ontospy(object):
 
         for candidate in qres:
 
-            test_existing_cl = self.getEntity(uri=candidate[0])
+            test_existing_cl = self.get_any_entity(uri=candidate[0])
             if not test_existing_cl:
                 # create it
                 self.all_shapes += [OntoShape(candidate[0], None, self.namespaces)]
@@ -509,7 +509,7 @@ class Ontospy(object):
 
             # attach to a class
             for uri in aShape.getValuesForProperty(shacl['targetClass']):
-                aclass = self.getClass(str(uri))
+                aclass = self.get_class(str(uri))
                 if aclass:
                     aShape.targetClasses += [aclass]
                     aclass.all_shapes += [aShape]
@@ -570,7 +570,7 @@ class Ontospy(object):
             if isBlankNode(x):
                 aProp.domains += [RDF_Entity(x, None, self.namespaces, is_Bnode=True)]
             else:
-                aClass = self.getClass(uri=str(x))
+                aClass = self.get_class(uri=str(x))
                 if aClass:
                     aProp.domains += [aClass]
                     aClass.domain_of += [aProp]
@@ -582,7 +582,7 @@ class Ontospy(object):
             if isBlankNode(x):
                 aProp.domains += [RDF_Entity(x, None, self.namespaces, is_Bnode=True)]
             else:
-                aClass = self.getClass(uri=str(x))
+                aClass = self.get_class(uri=str(x))
                 if aClass:
                     aProp.ranges += [aClass]
                     aClass.range_of += [aProp]
@@ -723,19 +723,19 @@ class Ontospy(object):
     # ================
 
 
-    def getClass(self, id=None, uri=None, match=None):
+    def get_class(self, id=None, uri=None, match=None):
         """
         get the saved-class with given ID or via other methods...
 
         Note: it tries to guess what is being passed..
 
-        In [1]: g.getClass(uri='http://www.w3.org/2000/01/rdf-schema#Resource')
+        In [1]: g.get_class(uri='http://www.w3.org/2000/01/rdf-schema#Resource')
         Out[1]: <Class *http://www.w3.org/2000/01/rdf-schema#Resource*>
 
-        In [2]: g.getClass(10)
+        In [2]: g.get_class(10)
         Out[2]: <Class *http://purl.org/ontology/bibo/AcademicArticle*>
 
-        In [3]: g.getClass(match="person")
+        In [3]: g.get_class(match="person")
         Out[3]:
         [<Class *http://purl.org/ontology/bibo/PersonalCommunicationDocument*>,
          <Class *http://purl.org/ontology/bibo/PersonalCommunication*>,
@@ -774,7 +774,7 @@ class Ontospy(object):
             return None
 
 
-    def getProperty(self, id=None, uri=None, match=None):
+    def get_property(self, id=None, uri=None, match=None):
         """
         get the saved-class with given ID or via other methods...
 
@@ -812,7 +812,7 @@ class Ontospy(object):
             return None
 
 
-    def getSkosConcept(self, id=None, uri=None, match=None):
+    def get_skos(self, id=None, uri=None, match=None):
         """
         get the saved skos concept with given ID or via other methods...
 
@@ -850,7 +850,7 @@ class Ontospy(object):
             return None
 
 
-    def getEntity(self, id=None, uri=None, match=None):
+    def get_any_entity(self, id=None, uri=None, match=None):
         """
         get a generic entity with given ID or via other methods...
         """
@@ -898,7 +898,7 @@ class Ontospy(object):
 
 
 
-    def getOntology(self, id=None, uri=None, match=None):
+    def get_ontology(self, id=None, uri=None, match=None):
         """
         get the saved-ontology with given ID or via other methods...
         """

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -527,6 +527,30 @@ class Ontospy(object):
 
 
 
+    def extract_entity_from_uri(self, uri):
+        """
+        Extract RDF statements having a URI as subject
+
+        Instatiate the RDF_Entity Python object so that it can be queried further.
+
+        NOTE: the entity is not attached to any index. In future version we may create an index for these (individuals?) keeping into account that any existing model entity could be (re)created this way.
+        """
+        qres = self.sparqlHelper.entityTriples(uri)
+        if qres:
+            entity = RDF_Entity(rdflib.URIRef(uri), None, self.namespaces)
+            entity.triples = qres
+            entity._buildGraph() # force construction of mini graph
+            # try to add class info
+            test = entity.getValuesForProperty(rdflib.RDF.type)
+            if test:
+                entity.rdftype = test
+                entity.rdftype_qname = [entity._build_qname(x) for x in test]
+            return entity
+        else:
+            return None
+
+
+
 
     # ------------
     # === methods to refine the ontology structure  === #

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -142,7 +142,7 @@ class Ontospy(object):
         # don't extract entities by default..
 
 
-    def serialize(self, format="turtle"):
+    def rdf_source(self, format="turtle"):
         """
         Wrapper for rdflib serializer method.
         Valid options are: xml, n3, turtle, nt, pretty-xml [trix not working out of the box]

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -63,6 +63,7 @@ class Ontospy(object):
         self.sources = None
         self.sparqlHelper = None
         self.namespaces = []
+        # entities buckets start with 'all_'
         self.all_ontologies = []
         self.all_classes = []
         self.all_properties = []
@@ -72,10 +73,10 @@ class Ontospy(object):
         self.all_skos_concepts = []
         self.all_shapes = []
         # self.all_individuals = []
-        self.toplayer = []
-        self.toplayerProperties = []
-        self.toplayerSkosConcepts = []
-        self.toplayerShapes = []
+        self.toplayer_classes  = []
+        self.toplayer_properties = []
+        self.toplayer_skos = []
+        self.toplayer_shapes = []
         self.OWLTHING = OntoClass(rdflib.OWL.Thing, rdflib.OWL.Class, self.namespaces)
 
         # finally:
@@ -325,7 +326,7 @@ class Ontospy(object):
         for c in self.all_classes:
             if not c.parents():
                 exit += [c]
-        self.toplayer = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_classes  = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
 
 
@@ -407,7 +408,7 @@ class Ontospy(object):
         for c in self.all_properties:
             if not c.parents():
                 exit += [c]
-        self.toplayerProperties = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_properties = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
 
 
@@ -469,7 +470,7 @@ class Ontospy(object):
         for c in self.all_skos_concepts:
             if not c.parents():
                 exit += [c]
-        self.toplayerSkosConcepts = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_skos = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
 
 
@@ -522,7 +523,7 @@ class Ontospy(object):
         for c in self.all_shapes:
             if not c.parents():
                 exit += [c]
-        self.toplayerShapes = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_shapes = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
 
 
@@ -604,21 +605,21 @@ class Ontospy(object):
         for c in self.all_classes:
             if not c.parents():
                 exit += [c]
-        self.toplayer = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_classes  = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
         # properties
         exit = []
         for c in self.all_properties:
             if not c.parents():
                 exit += [c]
-        self.toplayerProperties = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_properties = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
         # skos
         exit = []
         for c in self.all_skos_concepts:
             if not c.parents():
                 exit += [c]
-        self.toplayerSkosConcepts = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
+        self.toplayer_skos = exit  # sorted(exit, key=lambda x: x.id) # doesnt work
 
 
     def __computeInferredProperties(self):
@@ -997,7 +998,7 @@ class Ontospy(object):
         TYPE_MARGIN = 18 # length for owl:AnnotationProperty etc..
 
         if not element:	 # first time
-            for x in self.toplayerProperties:
+            for x in self.toplayer_properties:
                 printGenericTree(x, 0, showids, labels, showtype, TYPE_MARGIN)
 
         else:
@@ -1016,7 +1017,7 @@ class Ontospy(object):
         TYPE_MARGIN = 13 # length for skos:concept
 
         if not element:	 # first time
-            for x in self.toplayerSkosConcepts:
+            for x in self.toplayer_skos:
                 printGenericTree(x, 0, showids, labels, showtype, TYPE_MARGIN)
 
         else:
@@ -1047,7 +1048,7 @@ class Ontospy(object):
         """
         treedict = {}
         if self.all_properties:
-            treedict[0] = self.toplayerProperties
+            treedict[0] = self.toplayer_properties
             for element in self.all_properties:
                 if element.children():
                     treedict[element] = element.children()
@@ -1063,7 +1064,7 @@ class Ontospy(object):
         """
         treedict = {}
         if self.all_skos_concepts:
-            treedict[0] = self.toplayerSkosConcepts
+            treedict[0] = self.toplayer_skos
             for element in self.all_skos_concepts:
                 if element.children():
                     treedict[element] = element.children()
@@ -1080,7 +1081,7 @@ class Ontospy(object):
         """
         treedict = {}
         if self.all_shapes:
-            treedict[0] = self.toplayerShapes
+            treedict[0] = self.toplayer_shapes
             for element in self.all_shapes:
                 if element.children():
                     treedict[element] = element.children()

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -35,7 +35,7 @@ class Ontospy(object):
 
     In [7]: o.load_rdf("foaf.rdf")
 
-    In [11]: o.extract_entities()
+    In [11]: o.extract_all()
 
     In [13]: o.stats()
     Out[13]:
@@ -51,7 +51,7 @@ class Ontospy(object):
 
     """
 
-    def __init__(self, uri_or_path=None, text=None, file_obj=None, rdf_format="", verbose=False, hide_base_schemas=True, sparql_endpoint=None, credentials=None, extract_entities=True):
+    def __init__(self, uri_or_path=None, text=None, file_obj=None, rdf_format="", verbose=False, hide_base_schemas=True, sparql_endpoint=None, credentials=None, extract_all=True):
         """
         Load the graph in memory, then setup all necessary attributes.
         """
@@ -81,8 +81,8 @@ class Ontospy(object):
         # finally:
         if uri_or_path or text or file_obj:
             self.load_rdf(uri_or_path, text, file_obj, rdf_format, verbose, hide_base_schemas)
-            if extract_entities:
-                self.extract_entities(verbose=verbose, hide_base_schemas=hide_base_schemas)
+            if extract_all:
+                self.extract_all(verbose=verbose, hide_base_schemas=hide_base_schemas)
         elif sparql_endpoint: # by default entities are not extracted
             self.load_sparql(sparql_endpoint, verbose, hide_base_schemas, credentials)
         else:
@@ -161,7 +161,7 @@ class Ontospy(object):
     # === methods to build python objects === #
     # ------------
 
-    def extract_entities(self, verbose=False, hide_base_schemas=True):
+    def extract_all(self, verbose=False, hide_base_schemas=True):
         """
         Extract all ontology entities from an RDF graph and construct Python representations of them.
         """

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -62,7 +62,7 @@ class Ontospy(object):
         self.credentials = None  # tuple: auth credentials for endpoint if needed
         self.sources = None
         self.sparqlHelper = None
-        self.ontologies = []
+        self.all_ontologies = []
         self.classes = []
         self.namespaces = []
         self.properties = []
@@ -170,7 +170,7 @@ class Ontospy(object):
             printDebug("----------", "comment")
 
         self.extract_ontologies()
-        if verbose: printDebug("Ontologies.........: %d" % len(self.ontologies), "comment")
+        if verbose: printDebug("Ontologies.........: %d" % len(self.all_ontologies), "comment")
 
         self.extract_classes(hide_base_schemas)
         if verbose: printDebug("Classes............: %d" % len(self.classes), "comment")
@@ -243,8 +243,8 @@ class Ontospy(object):
             # printDebug("No owl:Ontologies found")
 
         #finally... add all annotations/triples
-        self.ontologies = out
-        for onto in self.ontologies:
+        self.all_ontologies = out
+        for onto in self.all_ontologies:
             onto.triples = self.sparqlHelper.entityTriples(onto.uri)
             onto._buildGraph() # force construction of mini graph
 
@@ -687,7 +687,7 @@ class Ontospy(object):
     def stats(self):
         """ shotcut to pull out useful info for a graph"""
         out = []
-        out += [("Ontologies", len(self.ontologies))]
+        out += [("Ontologies", len(self.all_ontologies))]
         out += [("Triples", self.triplesCount())]
         out += [("Classes", len(self.classes))]
         out += [("Properties", len(self.properties))]
@@ -915,12 +915,12 @@ class Ontospy(object):
             if type(match) != type("string"):
                 return []
             res = []
-            for x in self.ontologies:
+            for x in self.all_ontologies:
                 if match.lower() in x.uri.lower():
                     res += [x]
             return res
         else:
-            for x in self.ontologies:
+            for x in self.all_ontologies:
                 if id and x.id == id:
                     return x
                 if uri and x.uri.lower() == uri.lower():

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -67,7 +67,7 @@ class Ontospy(object):
         self.all_classes = []
         self.all_properties = []
         self.all_properties_annotation = []
-        self.objectProperties = []
+        self.all_properties_object = []
         self.datatypeProperties = []
         self.skosConcepts = []
         # self.individuals = []
@@ -179,7 +179,7 @@ class Ontospy(object):
         if verbose: printDebug("Properties.........: %d" % len(self.all_properties), "comment")
         if verbose: printDebug("..annotation.......: %d" % len(self.all_properties_annotation), "comment")
         if verbose: printDebug("..datatype.........: %d" % len(self.datatypeProperties), "comment")
-        if verbose: printDebug("..object...........: %d" % len(self.objectProperties), "comment")
+        if verbose: printDebug("..object...........: %d" % len(self.all_properties_object), "comment")
 
         self.extract_skos_concepts()
         if verbose: printDebug("Concepts (SKOS)....: %d" % len(self.skosConcepts), "comment")
@@ -342,7 +342,7 @@ class Ontospy(object):
         """
         self.all_properties = [] # @todo: keep adding?
         self.all_properties_annotation = []
-        self.objectProperties = []
+        self.all_properties_object = []
         self.datatypeProperties = []
 
         qres = self.sparqlHelper.getAllProperties()
@@ -367,7 +367,7 @@ class Ontospy(object):
             elif aProp.rdftype == rdflib.OWL.AnnotationProperty:
                 self.all_properties_annotation += [aProp]
             elif aProp.rdftype == rdflib.OWL.ObjectProperty:
-                self.objectProperties += [aProp]
+                self.all_properties_object += [aProp]
             else:
                 pass
 
@@ -692,7 +692,7 @@ class Ontospy(object):
         out += [("Classes", len(self.all_classes))]
         out += [("Properties", len(self.all_properties))]
         out += [("Annotation Properties", len(self.all_properties_annotation))]
-        out += [("Object Properties", len(self.objectProperties))]
+        out += [("Object Properties", len(self.all_properties_object))]
         out += [("Datatype Properties", len(self.datatypeProperties))]
         out += [("Skos Concepts", len(self.skosConcepts))]
         out += [("Data Shapes", len(self.shapes))]

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -70,7 +70,7 @@ class Ontospy(object):
         self.objectProperties = []
         self.datatypeProperties = []
         self.skosConcepts = []
-        self.individuals = []
+        # self.individuals = []
         self.shapes = []
         self.toplayer = []
         self.toplayerProperties = []

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -68,7 +68,7 @@ class Ontospy(object):
         self.all_properties = []
         self.all_properties_annotation = []
         self.all_properties_object = []
-        self.datatypeProperties = []
+        self.all_properties_datatype = []
         self.skosConcepts = []
         # self.individuals = []
         self.shapes = []
@@ -178,7 +178,7 @@ class Ontospy(object):
         self.extract_properties()
         if verbose: printDebug("Properties.........: %d" % len(self.all_properties), "comment")
         if verbose: printDebug("..annotation.......: %d" % len(self.all_properties_annotation), "comment")
-        if verbose: printDebug("..datatype.........: %d" % len(self.datatypeProperties), "comment")
+        if verbose: printDebug("..datatype.........: %d" % len(self.all_properties_datatype), "comment")
         if verbose: printDebug("..object...........: %d" % len(self.all_properties_object), "comment")
 
         self.extract_skos_concepts()
@@ -343,7 +343,7 @@ class Ontospy(object):
         self.all_properties = [] # @todo: keep adding?
         self.all_properties_annotation = []
         self.all_properties_object = []
-        self.datatypeProperties = []
+        self.all_properties_datatype = []
 
         qres = self.sparqlHelper.getAllProperties()
 
@@ -363,7 +363,7 @@ class Ontospy(object):
         for aProp in self.all_properties:
 
             if aProp.rdftype == rdflib.OWL.DatatypeProperty:
-                self.datatypeProperties += [aProp]
+                self.all_properties_datatype += [aProp]
             elif aProp.rdftype == rdflib.OWL.AnnotationProperty:
                 self.all_properties_annotation += [aProp]
             elif aProp.rdftype == rdflib.OWL.ObjectProperty:
@@ -693,7 +693,7 @@ class Ontospy(object):
         out += [("Properties", len(self.all_properties))]
         out += [("Annotation Properties", len(self.all_properties_annotation))]
         out += [("Object Properties", len(self.all_properties_object))]
-        out += [("Datatype Properties", len(self.datatypeProperties))]
+        out += [("Datatype Properties", len(self.all_properties_datatype))]
         out += [("Skos Concepts", len(self.skosConcepts))]
         out += [("Data Shapes", len(self.shapes))]
         # out += [("Individuals", len(self.individuals))] @TODO

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -35,7 +35,7 @@ class Ontospy(object):
 
     In [7]: o.load_rdf("foaf.rdf")
 
-    In [11]: o.extract_all()
+    In [11]: o.build_all()
 
     In [13]: o.stats()
     Out[13]:
@@ -51,7 +51,7 @@ class Ontospy(object):
 
     """
 
-    def __init__(self, uri_or_path=None, text=None, file_obj=None, rdf_format="", verbose=False, hide_base_schemas=True, sparql_endpoint=None, credentials=None, extract_all=True):
+    def __init__(self, uri_or_path=None, text=None, file_obj=None, rdf_format="", verbose=False, hide_base_schemas=True, sparql_endpoint=None, credentials=None, build_all=True):
         """
         Load the graph in memory, then setup all necessary attributes.
         """
@@ -82,8 +82,8 @@ class Ontospy(object):
         # finally:
         if uri_or_path or text or file_obj:
             self.load_rdf(uri_or_path, text, file_obj, rdf_format, verbose, hide_base_schemas)
-            if extract_all:
-                self.extract_all(verbose=verbose, hide_base_schemas=hide_base_schemas)
+            if build_all:
+                self.build_all(verbose=verbose, hide_base_schemas=hide_base_schemas)
         elif sparql_endpoint: # by default entities are not extracted
             self.load_sparql(sparql_endpoint, verbose, hide_base_schemas, credentials)
         else:
@@ -162,7 +162,7 @@ class Ontospy(object):
     # === methods to build python objects === #
     # ------------
 
-    def extract_all(self, verbose=False, hide_base_schemas=True):
+    def build_all(self, verbose=False, hide_base_schemas=True):
         """
         Extract all ontology entities from an RDF graph and construct Python representations of them.
         """
@@ -170,22 +170,22 @@ class Ontospy(object):
             printDebug("Scanning entities...", "green")
             printDebug("----------", "comment")
 
-        self.extract_ontologies()
+        self.build_ontologies()
         if verbose: printDebug("Ontologies.........: %d" % len(self.all_ontologies), "comment")
 
-        self.extract_classes(hide_base_schemas)
+        self.build_classes(hide_base_schemas)
         if verbose: printDebug("Classes............: %d" % len(self.all_classes), "comment")
 
-        self.extract_properties()
+        self.build_properties()
         if verbose: printDebug("Properties.........: %d" % len(self.all_properties), "comment")
         if verbose: printDebug("..annotation.......: %d" % len(self.all_properties_annotation), "comment")
         if verbose: printDebug("..datatype.........: %d" % len(self.all_properties_datatype), "comment")
         if verbose: printDebug("..object...........: %d" % len(self.all_properties_object), "comment")
 
-        self.extract_skos_concepts()
+        self.build_skos_concepts()
         if verbose: printDebug("Concepts (SKOS)....: %d" % len(self.all_skos_concepts), "comment")
 
-        self.extract_shapes()
+        self.build_shapes()
         if verbose: printDebug("Shapes (SHACL).....: %d" % len(self.all_shapes), "comment")
 
         # self.__computeTopLayer()
@@ -195,7 +195,7 @@ class Ontospy(object):
         if verbose: printDebug("----------", "comment")
 
 
-    def extract_ontologies(self, exclude_BNodes = False, return_string=False):
+    def build_ontologies(self, exclude_BNodes = False, return_string=False):
         """
         Extract ontology instances info from the graph, then creates python objects for them.
 
@@ -255,7 +255,7 @@ class Ontospy(object):
     #  RDFS:class vs OWL:class cf. http://www.w3.org/TR/owl-ref/ section 3.1
     #
 
-    def extract_classes(self, hide_base_schemas=True):
+    def build_classes(self, hide_base_schemas=True):
         """
         2015-06-04: removed sparql 1.1 queries
         2015-05-25: optimized via sparql queries in order to remove BNodes
@@ -331,7 +331,7 @@ class Ontospy(object):
 
 
 
-    def extract_properties(self):
+    def build_properties(self):
         """
         2015-06-04: removed sparql 1.1 queries
         2015-06-03: analogous to get classes
@@ -413,7 +413,7 @@ class Ontospy(object):
 
 
 
-    def extract_skos_concepts(self):
+    def build_skos_concepts(self):
         """
         2015-08-19: first draft
         """
@@ -475,7 +475,7 @@ class Ontospy(object):
 
 
 
-    def extract_shapes(self):
+    def build_shapes(self):
         """
         Extract SHACL data shapes from the rdf graph.
         <http://www.w3.org/ns/shacl#>
@@ -528,7 +528,7 @@ class Ontospy(object):
 
 
 
-    def extract_entity_from_uri(self, uri):
+    def build_entity_from_uri(self, uri):
         """
         Extract RDF statements having a URI as subject
 
@@ -979,7 +979,7 @@ class Ontospy(object):
         TYPE_MARGIN = 11 # length for owl:class etc..
 
         if not element:	 # first time
-            for x in self.toplayer:
+            for x in self.toplayer_classes:
                 printGenericTree(x, 0, showids, labels, showtype, TYPE_MARGIN)
 
         else:
@@ -1032,7 +1032,7 @@ class Ontospy(object):
         """
         treedict = {}
         if self.all_classes:
-            treedict[0] = self.toplayer
+            treedict[0] = self.toplayer_classes
             for element in self.all_classes:
                 if element.children():
                     treedict[element] = element.children()

--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -306,7 +306,7 @@ class Ontospy(object):
                     aClass.ontology = onto
 
             # add direct Supers
-            directSupers = self.sparqlHelper.get_classDirectSupers(aClass.uri)
+            directSupers = self.sparqlHelper.getClassDirectSupers(aClass.uri)
 
             for x in directSupers:
                 superclass = self.get_class(uri=x[0])

--- a/ontospy/core/rdf_loader.py
+++ b/ontospy/core/rdf_loader.py
@@ -46,7 +46,7 @@ class RDFLoader(object):
     def __init__(self, rdfgraph=None):
         super(RDFLoader, self).__init__()
 
-        self.rdfgraph = rdfgraph or rdflib.Graph()
+        self.rdflib_graph = rdfgraph or rdflib.Graph()
         self.sources_valid = []
         self.sources_invalid = []
 
@@ -98,7 +98,7 @@ class RDFLoader(object):
 
         if verbose: self.print_summary()
 
-        return self.rdfgraph
+        return self.rdflib_graph
 
 
 
@@ -109,7 +109,7 @@ class RDFLoader(object):
         """
         if self.sources_valid:
             printDebug("----------\nLoaded %d triples.\n----------" %
-                len(self.rdfgraph), fg='green')
+                len(self.rdflib_graph), fg='green')
             printDebug("RDF sources loaded successfully: %d of %d.\n----------" %
                 (len(self.sources_valid), len(self.sources_valid) + len(self.sources_invalid)), fg='green')
             for s in self.sources_valid:
@@ -140,7 +140,7 @@ class RDFLoader(object):
         for f in self.rdf_format_opts:
             if verbose: printDebug(".. trying rdf serialization: <%s>" % f)
             try:
-                self.rdfgraph.parse(uri, format=f)
+                self.rdflib_graph.parse(uri, format=f)
                 if verbose: printDebug("..... success!", bold=True)
                 success = True
                 self.sources_valid += [uri]
@@ -168,7 +168,7 @@ class RDFLoader(object):
         for f in self.rdf_format_opts:
             if verbose: printDebug(".. trying rdf serialization: <%s>" % f)
             try:
-                self.rdfgraph.parse(data=text, format=f)
+                self.rdflib_graph.parse(data=text, format=f)
                 if verbose: printDebug("..... success!")
                 success = True
                 self.sources_valid += ["Text: '%s ...'" % text[:10]]
@@ -192,7 +192,7 @@ class RDFLoader(object):
         if verbose: printDebug("Reading: <%s> ...'" % file_obj.name)
 
         if type(file_obj) == file:
-            self.rdfgraph = self.rdfgraph + file_obj
+            self.rdflib_graph = self.rdflib_graph + file_obj
             self.sources_valid += [file_obj.NAME]
         else:
             self.loading_failed(self.rdf_format_opts)

--- a/ontospy/core/sparqlHelper.py
+++ b/ontospy/core/sparqlHelper.py
@@ -34,7 +34,7 @@ class SparqlHelper(object):
 
     def __init__(self, rdfgraph, sparql_endpoint=False):
         super(SparqlHelper, self).__init__()
-        self.rdfgraph = rdfgraph
+        self.rdflib_graph = rdfgraph
         self.sparql_endpoint = sparql_endpoint
 
         # TODO add 2 versions of queries, one for declared classes only,
@@ -42,15 +42,15 @@ class SparqlHelper(object):
         self.inference = False
 
         # Bind a few prefix, namespace pairs for easier sparql querying
-        self.rdfgraph.bind("rdf", rdflib.namespace.RDF)
-        self.rdfgraph.bind("rdfs", rdflib.namespace.RDFS)
-        self.rdfgraph.bind("owl", rdflib.namespace.OWL)
-        self.rdfgraph.bind("skos", rdflib.namespace.SKOS)
-        self.rdfgraph.bind("dc", "http://purl.org/dc/elements/1.1/")
-        self.rdfgraph.bind("vann", "http://purl.org/vocab/vann/")
-        self.rdfgraph.bind("void", "http://rdfs.org/ns/void#")
-        self.rdfgraph.bind("xsd", "http://www.w3.org/2001/XMLSchema#")
-        self.rdfgraph.bind("sh", "http://www.w3.org/ns/shacl#")
+        self.rdflib_graph.bind("rdf", rdflib.namespace.RDF)
+        self.rdflib_graph.bind("rdfs", rdflib.namespace.RDFS)
+        self.rdflib_graph.bind("owl", rdflib.namespace.OWL)
+        self.rdflib_graph.bind("skos", rdflib.namespace.SKOS)
+        self.rdflib_graph.bind("dc", "http://purl.org/dc/elements/1.1/")
+        self.rdflib_graph.bind("vann", "http://purl.org/vocab/vann/")
+        self.rdflib_graph.bind("void", "http://rdfs.org/ns/void#")
+        self.rdflib_graph.bind("xsd", "http://www.w3.org/2001/XMLSchema#")
+        self.rdflib_graph.bind("sh", "http://www.w3.org/ns/shacl#")
 
 
     # ..................
@@ -59,7 +59,7 @@ class SparqlHelper(object):
 
 
     def getOntology(self):
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
             """SELECT DISTINCT ?x
                WHERE {
                   ?x a owl:Ontology
@@ -75,7 +75,7 @@ class SparqlHelper(object):
 
 
     def getShapes(self):
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
             """SELECT DISTINCT ?x
                WHERE {
                         { ?x a sh:Shape }
@@ -137,7 +137,7 @@ class SparqlHelper(object):
         else:
             query = query % ""
 
-        qres = self.rdfgraph.query(query)
+        qres = self.rdflib_graph.query(query)
         return list(qres)
 
 
@@ -150,7 +150,7 @@ class SparqlHelper(object):
 
         added: { ?y rdf:type ?x }
         """
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x ?c
                  WHERE {
                          {
@@ -187,7 +187,7 @@ class SparqlHelper(object):
 
     def getClassInstances(self, aURI):
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                      { ?x rdf:type <%s> }
@@ -198,7 +198,7 @@ class SparqlHelper(object):
 
     def getClassInstancesCount(self, aURI):
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT (COUNT(?x) AS ?count )
                  WHERE {
                      { ?x rdf:type <%s> }
@@ -214,7 +214,7 @@ class SparqlHelper(object):
 
     def getClassDirectSupers(self, aURI):
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                      { <%s> rdfs:subClassOf ?x }
@@ -229,7 +229,7 @@ class SparqlHelper(object):
         2015-06-03: currenlty not used, inferred from above
         """
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                      { ?x rdfs:subClassOf <%s> }
@@ -245,7 +245,7 @@ class SparqlHelper(object):
         """
         aURI = aURI
         try:
-            qres = self.rdfgraph.query(
+            qres = self.rdflib_graph.query(
                   """SELECT DISTINCT ?x
                      WHERE {
                          { <%s> rdfs:subClassOf+ ?x }
@@ -265,7 +265,7 @@ class SparqlHelper(object):
         """
         aURI = aURI
         try:
-            qres = self.rdfgraph.query(
+            qres = self.rdflib_graph.query(
                   """SELECT DISTINCT ?x
                      WHERE {
                          { ?x rdfs:subClassOf+ <%s> }
@@ -286,7 +286,7 @@ class SparqlHelper(object):
 
     # NOTE this kinf of query could be expanded to classes too!!!
     def getAllProperties(self):
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT ?x ?c WHERE {
                         {
                             { ?x a rdf:Property }
@@ -307,7 +307,7 @@ class SparqlHelper(object):
 
     def getPropDirectSupers(self, aURI):
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                      { <%s> rdfs:subPropertyOf ?x }
@@ -324,7 +324,7 @@ class SparqlHelper(object):
         """
         aURI = aURI
         try:
-            qres = self.rdfgraph.query(
+            qres = self.rdflib_graph.query(
                   """SELECT DISTINCT ?x
                      WHERE {
                          { <%s> rdfs:subPropertyOf+ ?x }
@@ -344,7 +344,7 @@ class SparqlHelper(object):
         """
         aURI = aURI
         try:
-            qres = self.rdfgraph.query(
+            qres = self.rdflib_graph.query(
                   """SELECT DISTINCT ?x
                      WHERE {
                          { ?x rdfs:subPropertyOf+ <%s> }
@@ -365,7 +365,7 @@ class SparqlHelper(object):
 
 
     def getSKOSInstances(self):
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                      { ?x rdf:type skos:Concept }
@@ -377,7 +377,7 @@ class SparqlHelper(object):
 
     def getSKOSDirectSupers(self, aURI):
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                          {
@@ -396,7 +396,7 @@ class SparqlHelper(object):
         2015-08-19: currenlty not used, inferred from above
         """
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """SELECT DISTINCT ?x
                  WHERE {
                          {
@@ -427,7 +427,7 @@ class SparqlHelper(object):
         """
 
         aURI = aURI
-        qres = self.rdfgraph.query(
+        qres = self.rdflib_graph.query(
               """CONSTRUCT {<%s> ?y ?z }
                  WHERE {
                      { <%s> ?y ?z }
@@ -441,7 +441,7 @@ class SparqlHelper(object):
             for tripl in triples_list:
                 if isBlankNode(tripl[2]):
                     # print "blank node", str(tripl[2])
-                    temp = [x for x in self.rdfgraph.triples((tripl[2], None, None))]
+                    temp = [x for x in self.rdflib_graph.triples((tripl[2], None, None))]
                     out += temp + recurse(temp)
                 else:
                     pass

--- a/ontospy/core/utils.py
+++ b/ontospy/core/utils.py
@@ -915,12 +915,12 @@ def shellPrintOverview(g, opts={'labels' : False}):
     if g.all_properties:
         print(Style.BRIGHT + "\nProperty Taxonomy\n" + "-" * 10	 + Style.RESET_ALL)
         g.printPropertyTree(showids=False, labels=opts['labels'])
-    if g.skosConcepts:
+    if g.all_skos_concepts:
         print(Style.BRIGHT + "\nSKOS Taxonomy\n" + "-" * 10	 + Style.RESET_ALL)
         g.printSkosTree(showids=False, labels=opts['labels'])
-    if g.shapes:
+    if g.all_shapes:
         print(Style.BRIGHT + "\nSHACL Shapes\n" + "-" * 10	 + Style.RESET_ALL)
-        for x in g.shapes:
+        for x in g.all_shapes:
             printDebug("%s" % (x.qname))
             # printDebug("%s" % (x.bestLabel()), "comment")
 

--- a/ontospy/core/utils.py
+++ b/ontospy/core/utils.py
@@ -904,7 +904,7 @@ def shellPrintOverview(g, opts={'labels' : False}):
     # pydoc.pager("SOME_VERY_LONG_TEXT")
 
     """
-    ontologies = g.ontologies
+    ontologies = g.all_ontologies
 
     for o in ontologies:
         print(Style.BRIGHT + "\nOntology Annotations\n-----------" + Style.RESET_ALL)

--- a/ontospy/core/utils.py
+++ b/ontospy/core/utils.py
@@ -447,7 +447,7 @@ def inferMainPropertyType(uriref):
     Attempt to reduce the property types to 4 main types
     (without the OWL ontology - which would be the propert way)
 
-    In [3]: for x in g.properties:
+    In [3]: for x in g.all_properties:
        ...:		print x.rdftype
        ...:
     http://www.w3.org/2002/07/owl#FunctionalProperty
@@ -912,7 +912,7 @@ def shellPrintOverview(g, opts={'labels' : False}):
     if g.all_classes:
         print(Style.BRIGHT + "\nClass Taxonomy\n" + "-" * 10  + Style.RESET_ALL)
         g.printClassTree(showids=False, labels=opts['labels'])
-    if g.properties:
+    if g.all_properties:
         print(Style.BRIGHT + "\nProperty Taxonomy\n" + "-" * 10	 + Style.RESET_ALL)
         g.printPropertyTree(showids=False, labels=opts['labels'])
     if g.skosConcepts:

--- a/ontospy/core/utils.py
+++ b/ontospy/core/utils.py
@@ -412,7 +412,7 @@ def printBasicInfo(onto):
     """
     Terminal printing of basic ontology information
     """
-    rdfGraph = onto.rdfGraph
+    rdfGraph = onto.rdflib_graph
 
     print("_" * 50, "\n")
     print("TRIPLES = %s" % len(rdfGraph))

--- a/ontospy/core/utils.py
+++ b/ontospy/core/utils.py
@@ -802,8 +802,10 @@ def niceString2uri(aUriString, namespaces = None):
 
 
 
-def entityTriples(rdfGraph, anEntity, excludeProps=False, excludeBNodes = False, orderProps=[RDF, RDFS, OWL.OWLNS, DC.DCNS]):
+def xxx_entityTriples(rdfGraph, anEntity, excludeProps=False, excludeBNodes = False, orderProps=[RDF, RDFS, OWL.OWLNS, DC.DCNS]):
     """
+    2018-05-08: can delete? same name as sparqlHelper.entityTriples..
+
     Returns the pred-obj for any given resource, excluding selected ones..
 
     Sorting: by default results are sorted alphabetically and according to namespaces: [RDF, RDFS, OWL.OWLNS, DC.DCNS]

--- a/ontospy/core/utils.py
+++ b/ontospy/core/utils.py
@@ -909,7 +909,7 @@ def shellPrintOverview(g, opts={'labels' : False}):
     for o in ontologies:
         print(Style.BRIGHT + "\nOntology Annotations\n-----------" + Style.RESET_ALL)
         o.printTriples()
-    if g.classes:
+    if g.all_classes:
         print(Style.BRIGHT + "\nClass Taxonomy\n" + "-" * 10  + Style.RESET_ALL)
         g.printClassTree(showids=False, labels=opts['labels'])
     if g.properties:

--- a/ontospy/extras/hacks/compare.py
+++ b/ontospy/extras/hacks/compare.py
@@ -70,7 +70,7 @@ def compare(referenceOnto, somegraph):
 
 	return {'stats' : {	'classes': len(spy2.allclasses),
 						'properties' : len(spy2.allinferredproperties),
-						'triples' : len(spy2.rdfGraph)},
+						'triples' : len(spy2.rdflib_graph)},
 			'class_comparison' : class_comparison ,
 			'prop_comparison' : prop_comparison}
 

--- a/ontospy/extras/hacks/matcher.py
+++ b/ontospy/extras/hacks/matcher.py
@@ -85,10 +85,10 @@ def matcher(graph1, graph2, confidence=0.5, output_file="matching_results.csv", 
 
 		if class_or_prop == "classes":
 
-			for x in graph1.classes:
+			for x in graph1.all_classes:
 				l1 = unicode(x.bestLabel(qname_allowed=True))
 
-				for y in graph2.classes:
+				for y in graph2.all_classes:
 					l2 = unicode(y.bestLabel(qname_allowed=True))
 
 					if similar(l1, l2) > confidence:

--- a/ontospy/extras/hacks/matcher.py
+++ b/ontospy/extras/hacks/matcher.py
@@ -103,10 +103,10 @@ def matcher(graph1, graph2, confidence=0.5, output_file="matching_results.csv", 
 
 		elif class_or_prop == "properties":
 
-			for x in graph1.properties:
+			for x in graph1.all_properties:
 				l1 = unicode(x.bestLabel(qname_allowed=True))
 
-				for y in graph2.properties:
+				for y in graph2.all_properties:
 					l2 = unicode(y.bestLabel(qname_allowed=True))
 
 					if similar(l1, l2) > confidence:

--- a/ontospy/extras/hacks/sketch.py
+++ b/ontospy/extras/hacks/sketch.py
@@ -203,7 +203,7 @@ def main(argv=None):
 		print("Argument passing not implemented yet")
 		if False:
 			onto = Model(argv[0])
-			for x in onto.getClasses():
+			for x in onto.get_classes():
 				print(x)
 			onto.buildPythonClasses()
 			s = Sketch()

--- a/ontospy/extras/hacks/sketch.py
+++ b/ontospy/extras/hacks/sketch.py
@@ -119,7 +119,7 @@ class Sketch(object):
 		self.rdflib_graph.remove((None, None, None))
 
 
-	def serialize(self, aformat="turtle"):
+	def rdf_source(self, aformat="turtle"):
 		"""
 		Serialize graph using the format required
 		"""
@@ -148,7 +148,7 @@ class Sketch(object):
 
 	def omnigraffle(self):
 		""" tries to open an export directly in omnigraffle """
-		temp = self.serialize("dot")
+		temp = self.rdf_source("dot")
 
 		try:  # try to put in the user/tmp folder
 			from os.path import expanduser
@@ -167,7 +167,7 @@ class Sketch(object):
 
 
 	def show(self, aformat="turtle"):
-		print(self.serialize(aformat))
+		print(self.rdf_source(aformat))
 
 	def docs(self):
 		print(self.__docs__)

--- a/ontospy/extras/hacks/sketch.py
+++ b/ontospy/extras/hacks/sketch.py
@@ -56,8 +56,8 @@ class Sketch(object):
 	def __init__(self, text=""):
 		super(Sketch, self).__init__()
 
-		self.rdfGraph = rdflib.Graph()
-		self.namespace_manager = NamespaceManager(self.rdfGraph)
+		self.rdflib_graph = rdflib.Graph()
+		self.namespace_manager = NamespaceManager(self.rdflib_graph)
 
 		self.SUPPORTED_FORMATS = ['xml', 'n3', 'turtle', 'nt', 'pretty-xml', 'dot']
 
@@ -82,7 +82,7 @@ class Sketch(object):
 			self.continuousAdd()
 		else:
 			pprefix = ""
-			for x,y in self.rdfGraph.namespaces():
+			for x,y in self.rdflib_graph.namespaces():
 				pprefix += "@prefix %s: <%s> . \n" % (x, y)
 			# add final . if missing
 			if text and (not text.strip().endswith(".")):
@@ -91,7 +91,7 @@ class Sketch(object):
 			text = text.replace(" sub ", " rdfs:subClassOf ")
 			text = text.replace(" class ", " owl:Class ")
 			# finally
-			self.rdfGraph.parse(data=pprefix+text, format="turtle")
+			self.rdflib_graph.parse(data=pprefix+text, format="turtle")
 
 
 	# note: problem here if typying ### on first line!
@@ -109,14 +109,14 @@ class Sketch(object):
 
 	def bind(self, prefixTuple):
 		p, k = prefixTuple
-		self.rdfGraph.bind(p, k)
+		self.rdflib_graph.bind(p, k)
 
 	def clear(self):
 		""""
 		Clears the graph
 			@todo add ability to remove specific triples
 		"""
-		self.rdfGraph.remove((None, None, None))
+		self.rdflib_graph.remove((None, None, None))
 
 
 	def serialize(self, aformat="turtle"):
@@ -129,7 +129,7 @@ class Sketch(object):
 			return self.__serializedDot()
 		else:
 			# use stardard rdf serializations
-			return self.rdfGraph.serialize(format=aformat)
+			return self.rdflib_graph.serialize(format=aformat)
 
 	def __serializedDot(self):
 		"""
@@ -140,7 +140,7 @@ class Sketch(object):
 		 }
 		"""
 		temp = ""
-		for x,y,z in self.rdfGraph.triples((None, None, None)):
+		for x,y,z in self.rdflib_graph.triples((None, None, None)):
 			temp += """"%s" -> "%s" [label="%s"];\n""" % (self.namespace_manager.normalizeUri(x), self.namespace_manager.normalizeUri(z), self.namespace_manager.normalizeUri(y))
 		temp = "digraph graphname {\n%s}" % temp
 		return temp

--- a/ontospy/extras/hacks/turtle-cli.py
+++ b/ontospy/extras/hacks/turtle-cli.py
@@ -42,7 +42,7 @@ def clear_screen():
 def get_default_preds():
     """dynamically build autocomplete options based on an external file"""
     g = ontospy.Ontospy(rdfsschema, text=True, verbose=False, hide_base_schemas=False)
-    classes = [(x.qname, x.bestDescription()) for x in g.classes]
+    classes = [(x.qname, x.bestDescription()) for x in g.all_classes]
     properties = [(x.qname, x.bestDescription()) for x in g.properties]
     commands = [('exit', 'exits the terminal'), ('show', 'show current buffer')]
     return rdfschema + owlschema + classes + properties + commands

--- a/ontospy/extras/hacks/turtle-cli.py
+++ b/ontospy/extras/hacks/turtle-cli.py
@@ -43,7 +43,7 @@ def get_default_preds():
     """dynamically build autocomplete options based on an external file"""
     g = ontospy.Ontospy(rdfsschema, text=True, verbose=False, hide_base_schemas=False)
     classes = [(x.qname, x.bestDescription()) for x in g.all_classes]
-    properties = [(x.qname, x.bestDescription()) for x in g.properties]
+    properties = [(x.qname, x.bestDescription()) for x in g.all_properties]
     commands = [('exit', 'exits the terminal'), ('show', 'show current buffer')]
     return rdfschema + owlschema + classes + properties + commands
 

--- a/ontospy/extras/shell.py
+++ b/ontospy/extras/shell.py
@@ -28,6 +28,17 @@ from .shell_lib import Shell, STARTUP_MESSAGE
 
 
 
+def launch_shell(source=None):
+    Shell()._clear_screen()
+    print(STARTUP_MESSAGE)
+    if source and len(source) > 1:
+        click.secho('Note: currently only one argument can be passed', fg='red')
+    uri = source[0] if source else None
+    Shell(uri).cmdloop()
+    raise SystemExit(1)
+
+
+
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 # @click.option('--source', '-s',  multiple=True, help='Load the shell with a specific graph (uri or file)')
@@ -43,13 +54,7 @@ Note: if a local path or URI of an RDF model is provided, that gets loaded into 
 > ontospy-shell path/to/mymodel.rdf
 
 """
-    Shell()._clear_screen()
-    print(STARTUP_MESSAGE)
-    if source and len(source) > 1:
-        click.secho('Note: currently only one argument can be passed', fg='red')
-    uri = source[0] if source else None
-    Shell(uri).cmdloop()
-    raise SystemExit(1)
+    launch_shell(source)
 
 
 

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -118,7 +118,7 @@ class Shell(cmd.Cmd):
         # useful vars
         self.LOCAL = ONTOSPY_LOCAL
         self.LOCAL_MODELS = manager.get_home_location()
-        self.ontologies = manager.get_localontologies()
+        self.all_ontologies = manager.get_localontologies()
         self.current = None
         self.currentEntity = None
         if uri:
@@ -238,7 +238,7 @@ class Shell(cmd.Cmd):
         """
         if hrlinetop:
             self._print("----------------", "TIP")
-        self._print("Ontologies......: %d" % len(graph.ontologies), "TIP")
+        self._print("Ontologies......: %d" % len(graph.all_ontologies), "TIP")
         self._print("Classes.........: %d" % len(graph.classes), "TIP")
         self._print("Properties......: %d" % len(graph.properties), "TIP")
         self._print("..annotation....: %d" % len(graph.annotationProperties), "TIP")
@@ -268,7 +268,7 @@ class Shell(cmd.Cmd):
             self._print("Graph: <" + self.current['fullpath'] + ">", 'TIP')
             self._print("----------------", "TIP")
             self._printStats(self.current['graph'])
-            for obj in self.current['graph'].ontologies:
+            for obj in self.current['graph'].all_ontologies:
                 print(Style.BRIGHT + "Ontology URI: " + Style.RESET_ALL+ Fore.RED + "<%s>" % str(obj.uri) + Style.RESET_ALL)
                 # self._print("==> Ontology URI: <%s>" % str(obj.uri), "IMPORTANT")
                 # self._print("----------------", "TIP")
@@ -530,10 +530,10 @@ class Shell(cmd.Cmd):
         """Dynamically retrieves the next ontology in the list"""
         currentfile = self.current['file']
         try:
-            idx = self.ontologies.index(currentfile)
-            return self.ontologies[idx+1]
+            idx = self.all_ontologies.index(currentfile)
+            return self.all_ontologies[idx+1]
         except:
-            return self.ontologies[0]
+            return self.all_ontologies[0]
 
 
 
@@ -568,11 +568,11 @@ class Shell(cmd.Cmd):
         """try to select an ontology NP: the actual load from FS is in <_load_ontology> """
         try:
             var = int(line)	 # it's a string
-            if var in range(1, len(self.ontologies)+1):
-                self._load_ontology(self.ontologies[var-1])
+            if var in range(1, len(self.all_ontologies)+1):
+                self._load_ontology(self.all_ontologies[var-1])
         except ValueError:
             out = []
-            for each in self.ontologies:
+            for each in self.all_ontologies:
                 if line in each:
                     out += [each]
             choice = self._selectFromList(out, line, "ontology")
@@ -667,12 +667,12 @@ class Shell(cmd.Cmd):
         """	Delete an ontology
             2016-04-11: not a direct command anymore """
 
-        if not self.ontologies:
+        if not self.all_ontologies:
             self._help_nofiles()
 
         else:
             out = []
-            for each in self.ontologies:
+            for each in self.all_ontologies:
                 if line in each:
                     out += [each]
             choice = self._selectFromList(out, line)
@@ -687,7 +687,7 @@ class Shell(cmd.Cmd):
                         os.remove(fullpath)
                         manager.del_pickled_ontology(choice)
                         self._print("<%s> was deleted succesfully." % choice)
-                        self.ontologies = manager.get_localontologies()
+                        self.all_ontologies = manager.get_localontologies()
                     else:
                         return
 
@@ -706,11 +706,11 @@ class Shell(cmd.Cmd):
         """Rename an ontology
             2016-04-11: not a direct command anymore """
 
-        if not self.ontologies:
+        if not self.all_ontologies:
             self._help_nofiles()
         else:
             out = []
-            for each in self.ontologies:
+            for each in self.all_ontologies:
                 if line in each:
                     out += [each]
             choice = self._selectFromList(out, line)
@@ -728,7 +728,7 @@ class Shell(cmd.Cmd):
                             os.rename(fullpath, self.LOCAL_MODELS + "/" + var)
                             manager.rename_pickled_ontology(choice, var)
                             self._print("<%s> was renamed succesfully." % choice)
-                            self.ontologies = manager.get_localontologies()
+                            self.all_ontologies = manager.get_localontologies()
                         except:
                             self._print("Not a valid name. An error occurred.")
                             return
@@ -777,7 +777,7 @@ class Shell(cmd.Cmd):
             # self._print("Usage: ls [%s]" % "|".join([x for x in opts]))
 
         elif line[0] == "ontologies":
-            if not self.ontologies:
+            if not self.all_ontologies:
                 self._help_nofiles()
             else:
                 self._select_ontology(_pattern)
@@ -869,7 +869,7 @@ class Shell(cmd.Cmd):
             # self._print("Usage: get [%s] <name>" % "|".join([x for x in opts]))
 
         elif line[0] == "ontology":
-            if not self.ontologies:
+            if not self.all_ontologies:
                 self._help_nofiles()
             else:
                 self._select_ontology(_pattern)
@@ -1050,7 +1050,7 @@ class Shell(cmd.Cmd):
         else:
             self.help_import()
 
-        self.ontologies = manager.get_localontologies()
+        self.all_ontologies = manager.get_localontologies()
         return
 
 
@@ -1058,7 +1058,7 @@ class Shell(cmd.Cmd):
         """PErform some file operation"""
         opts = self.FILE_OPTS
 
-        if not self.ontologies:
+        if not self.all_ontologies:
             self._help_nofiles()
             return
 
@@ -1100,7 +1100,7 @@ class Shell(cmd.Cmd):
         else:
             self._print(g.rdf_source(format=line[0]))
             # 2016-05-27: was like this before
-            # for o in g.ontologies:
+            # for o in g.all_ontologies:
             # 	o.printSerialize(line[0])
 
 
@@ -1123,7 +1123,7 @@ class Shell(cmd.Cmd):
             else:
                 print("Not implemented")
         else:
-            if len(self.ontologies) > 1:
+            if len(self.all_ontologies) > 1:
                 nextonto = self._next_ontology()
                 self._load_ontology(nextonto)
             else:

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -243,7 +243,7 @@ class Shell(cmd.Cmd):
         self._print("Properties......: %d" % len(graph.all_properties), "TIP")
         self._print("..annotation....: %d" % len(graph.all_properties_annotation), "TIP")
         self._print("..datatype......: %d" % len(graph.datatypeProperties), "TIP")
-        self._print("..object........: %d" % len(graph.objectProperties), "TIP")
+        self._print("..object........: %d" % len(graph.all_properties_object), "TIP")
         self._print("Concepts(SKOS)..: %d" % len(graph.skosConcepts), "TIP")
         self._print("----------------", "TIP")
 

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -244,7 +244,7 @@ class Shell(cmd.Cmd):
         self._print("..annotation....: %d" % len(graph.all_properties_annotation), "TIP")
         self._print("..datatype......: %d" % len(graph.all_properties_datatype), "TIP")
         self._print("..object........: %d" % len(graph.all_properties_object), "TIP")
-        self._print("Concepts(SKOS)..: %d" % len(graph.skosConcepts), "TIP")
+        self._print("Concepts(SKOS)..: %d" % len(graph.all_skos_concepts), "TIP")
         self._print("----------------", "TIP")
 
 
@@ -641,7 +641,7 @@ class Shell(cmd.Cmd):
         """try to match a class and load it"""
         g = self.current['graph']
         if not line:
-            out = g.skosConcepts
+            out = g.all_skos_concepts
             using_pattern=False
         else:
             using_pattern=True
@@ -803,7 +803,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "concepts":
             g = self.current['graph']
-            if g.skosConcepts:
+            if g.all_skos_concepts:
                 self._select_concept(_pattern)
             else:
                 self._print("No concepts available.")
@@ -847,7 +847,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "concepts":
             g = self.current['graph']
-            if g.skosConcepts:
+            if g.all_skos_concepts:
                 g.printSkosTree(showids=False, labels=False, showtype=True)
             else:
                 self._print("No concepts available.")
@@ -894,7 +894,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "concept":
             g = self.current['graph']
-            if g.skosConcepts:
+            if g.all_skos_concepts:
                 self._select_concept(_pattern)
             else:
                 self._print("No concepts available.")

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -242,7 +242,7 @@ class Shell(cmd.Cmd):
         self._print("Classes.........: %d" % len(graph.all_classes), "TIP")
         self._print("Properties......: %d" % len(graph.all_properties), "TIP")
         self._print("..annotation....: %d" % len(graph.all_properties_annotation), "TIP")
-        self._print("..datatype......: %d" % len(graph.datatypeProperties), "TIP")
+        self._print("..datatype......: %d" % len(graph.all_properties_datatype), "TIP")
         self._print("..object........: %d" % len(graph.all_properties_object), "TIP")
         self._print("Concepts(SKOS)..: %d" % len(graph.skosConcepts), "TIP")
         self._print("----------------", "TIP")

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -239,7 +239,7 @@ class Shell(cmd.Cmd):
         if hrlinetop:
             self._print("----------------", "TIP")
         self._print("Ontologies......: %d" % len(graph.all_ontologies), "TIP")
-        self._print("Classes.........: %d" % len(graph.classes), "TIP")
+        self._print("Classes.........: %d" % len(graph.all_classes), "TIP")
         self._print("Properties......: %d" % len(graph.properties), "TIP")
         self._print("..annotation....: %d" % len(graph.annotationProperties), "TIP")
         self._print("..datatype......: %d" % len(graph.datatypeProperties), "TIP")
@@ -587,7 +587,7 @@ class Shell(cmd.Cmd):
         """
         g = self.current['graph']
         if not line:
-            out = g.classes
+            out = g.all_classes
             using_pattern=False
         else:
             using_pattern=True
@@ -789,7 +789,7 @@ class Shell(cmd.Cmd):
         elif line[0] == "classes":
             g = self.current['graph']
 
-            if g.classes:
+            if g.all_classes:
                 self._select_class(_pattern)
             else:
                 self._print("No classes available.")
@@ -832,7 +832,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "classes":
             g = self.current['graph']
-            if g.classes:
+            if g.all_classes:
                 g.printClassTree(showids=False, labels=False, showtype=True)
                 self._print("----------------", "TIP")
             else:
@@ -880,7 +880,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "class":
             g = self.current['graph']
-            if g.classes:
+            if g.all_classes:
                 self._select_class(_pattern)
             else:
                 self._print("No classes available.")

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -583,7 +583,7 @@ class Shell(cmd.Cmd):
     def _select_class(self, line):
         """
         try to match a class and load it from the graph
-        NOTE: the g.getClass(pattern) method does the heavy lifting
+        NOTE: the g.get_class(pattern) method does the heavy lifting
         """
         g = self.current['graph']
         if not line:
@@ -593,7 +593,7 @@ class Shell(cmd.Cmd):
             using_pattern=True
             if line.isdigit():
                 line =	int(line)
-            out = g.getClass(line)
+            out = g.get_class(line)
         if out:
             if type(out) == type([]):
                 choice = self._selectFromList(out, using_pattern, "class")
@@ -620,7 +620,7 @@ class Shell(cmd.Cmd):
             using_pattern=True
             if line.isdigit():
                 line =	int(line)
-            out = g.getProperty(line)
+            out = g.get_property(line)
         if out:
             if type(out) == type([]):
                 choice = self._selectFromList(out, using_pattern, "property")
@@ -647,7 +647,7 @@ class Shell(cmd.Cmd):
             using_pattern=True
             if line.isdigit():
                 line =	int(line)
-            out = g.getSkosConcept(line)
+            out = g.get_skos(line)
         if out:
             if type(out) == type([]):
                 choice = self._selectFromList(out, using_pattern, "concept")

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -1098,7 +1098,7 @@ class Shell(cmd.Cmd):
             self.currentEntity['object'].printSerialize(line[0])
 
         else:
-            self._print(g.serialize(format=line[0]))
+            self._print(g.rdf_source(format=line[0]))
             # 2016-05-27: was like this before
             # for o in g.ontologies:
             # 	o.printSerialize(line[0])

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -1000,9 +1000,9 @@ class Shell(cmd.Cmd):
 
         try:
             # from ..viz.builder import action_visualize
-            from ontospydocs import action_visualize
+            from ontodocs.core.builder import action_visualize
         except:
-            self._print("You need the ontospy-docs library for this: `pip install ontospy-docs`")
+            self._print("This command requires the ontodocs package: `pip install ontodocs`")
             return
 
         import webbrowser

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -240,8 +240,8 @@ class Shell(cmd.Cmd):
             self._print("----------------", "TIP")
         self._print("Ontologies......: %d" % len(graph.all_ontologies), "TIP")
         self._print("Classes.........: %d" % len(graph.all_classes), "TIP")
-        self._print("Properties......: %d" % len(graph.properties), "TIP")
-        self._print("..annotation....: %d" % len(graph.annotationProperties), "TIP")
+        self._print("Properties......: %d" % len(graph.all_properties), "TIP")
+        self._print("..annotation....: %d" % len(graph.all_properties_annotation), "TIP")
         self._print("..datatype......: %d" % len(graph.datatypeProperties), "TIP")
         self._print("..object........: %d" % len(graph.objectProperties), "TIP")
         self._print("Concepts(SKOS)..: %d" % len(graph.skosConcepts), "TIP")
@@ -614,7 +614,7 @@ class Shell(cmd.Cmd):
         """try to match a property and load it"""
         g = self.current['graph']
         if not line:
-            out = g.properties
+            out = g.all_properties
             using_pattern=False
         else:
             using_pattern=True
@@ -796,7 +796,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "properties":
             g = self.current['graph']
-            if g.properties:
+            if g.all_properties:
                 self._select_property(_pattern)
             else:
                 self._print("No properties available.")
@@ -840,7 +840,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "properties":
             g = self.current['graph']
-            if g.properties:
+            if g.all_properties:
                 g.printPropertyTree(showids=False, labels=False, showtype=True)
             else:
                 self._print("No properties available.")
@@ -887,7 +887,7 @@ class Shell(cmd.Cmd):
 
         elif line[0] == "property":
             g = self.current['graph']
-            if g.properties:
+            if g.all_properties:
                 self._select_property(_pattern)
             else:
                 self._print("No properties available.")

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -939,17 +939,17 @@ class Shell(cmd.Cmd):
 
 
         elif line[0] == "toplayer":
-            if g.toplayer:
+            if g.toplayer_classes:
                 self._print("Top Classes\n----------------", "IMPORTANT")
-            for x in g.toplayer:
+            for x in g.toplayer_classes:
                     self._print(x.qname)
-            if g.toplayerProperties:
+            if g.toplayer_properties:
                 self._print("\nTop Properties\n----------------", "IMPORTANT")
-                for x in g.toplayerProperties:
+                for x in g.toplayer_properties:
                     self._print(x.qname)
-            if g.toplayerSkosConcepts:
+            if g.toplayer_skos:
                 self._print("\nTop Concepts (SKOS)\n----------------", "IMPORTANT")
-                for x in g.toplayerSkosConcepts:
+                for x in g.toplayer_skos:
                     self._print(x.qname)
 
         elif line[0] == "namespaces":

--- a/ontospy/extras/shell_lib.py
+++ b/ontospy/extras/shell_lib.py
@@ -446,7 +446,7 @@ class Shell(cmd.Cmd):
         if self.currentEntity['type'] == 'class':
             if hrlinetop:
                 self._print("----------------")
-            self._print("INSTANCES: [%d]" % len(x.instances, "IMPORTANT")
+            self._print("INSTANCES: [%d]" % len(x.instances, "IMPORTANT"))
             for i in x.instances:
                 self._print(i.qname)
             self._print("----------------")

--- a/ontospy/main.py
+++ b/ontospy/main.py
@@ -76,7 +76,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--save', '-s', is_flag=True, help='SAVE: save a file/folder/url into the local library.')
 @click.option('--reset', '-r', is_flag=True, help='RESET: delete all files in the local library.')
 @click.option('--update', '-u', is_flag=True, help='UPDATE: enter new path for the local library.')
-@click.option('--verbose', '-v', is_flag=True, help='VERBOSE: show entities labels as well as URIs.')
+@click.option('--verbose', '-v', is_flag=True, help='VERBOSE: verbose logs and entities labels.')
 @click.option('--web', '-w', is_flag=True, help='WEB: import ontologies from remote repositories.')
 @click.option('--shell', '-z', is_flag=True, help='SHELL: launch the interactive shell.')
 @click.pass_context

--- a/ontospy/main.py
+++ b/ontospy/main.py
@@ -165,7 +165,7 @@ More info: <ontospy.readthedocs.org>
         # raise SystemExit(1)
 
     else:
-        if sources or endpoint:
+        if sources or (sources and endpoint):
             t = "You passed the arguments:%s" % "".join([ "\n-> <%s>" % str(x) for x in sources])
             click.secho(str(t), fg='green')
             if endpoint:

--- a/ontospy/main.py
+++ b/ontospy/main.py
@@ -177,10 +177,10 @@ More info: <ontospy.readthedocs.org>
             if endpoint:
                 g = Ontospy(sparql_endpoint=sources[0], verbose=verbose)
                 printDebug("Extracting classes info")
-                g.extract_classes()
+                g.build_classes()
                 printDebug("..done")
                 printDebug("Extracting properties info")
-                g.extract_properties()
+                g.build_properties()
                 printDebug("..done")
             else:
                 g = Ontospy(uri_or_path=sources, verbose=verbose)

--- a/ontospy/main.py
+++ b/ontospy/main.py
@@ -78,7 +78,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--update', '-u', is_flag=True, help='UPDATE: enter new path for the local library.')
 @click.option('--verbose', '-v', is_flag=True, help='VERBOSE: show entities labels as well as URIs.')
 @click.option('--web', '-w', is_flag=True, help='WEB: import ontologies from remote repositories.')
-def main_cli(sources=None, library=False, verbose=False, save=False, bootstrap=False, web=False, cache=False, update=False, delete=False, reset=False, endpoint=False):
+@click.pass_context
+def main_cli(ctx, sources=None, library=False, verbose=False, save=False, bootstrap=False, web=False, cache=False, update=False, delete=False, reset=False, endpoint=False):
     """
 Ontospy is a command line inspector for RDF/OWL knowledge models.
 
@@ -182,19 +183,8 @@ More info: <ontospy.readthedocs.org>
             shellPrintOverview(g, print_opts)
 
         else:
-            # click.secho("You haven't specified any argument.\nShowing the local library: '%s'" % get_home_location(), fg='red')
-            click.secho("You haven't specified any argument.", fg='red')
-            if click.confirm('Show the local library?'):
-                filename = action_listlocal(all_details=False)
-                if filename:
-                    g = get_pickled_ontology(filename)
-                    if not g:
-                        g = do_pickle_ontology(filename)
-                    shellPrintOverview(g, print_opts)
-            else:
-                printDebug("Goodbye.", "comment")
-                raise SystemExit(1)
-
+            click.echo(ctx.get_help())
+            return
 
 
     # finally: print(some stats.... )

--- a/ontospy/main.py
+++ b/ontospy/main.py
@@ -78,8 +78,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--update', '-u', is_flag=True, help='UPDATE: enter new path for the local library.')
 @click.option('--verbose', '-v', is_flag=True, help='VERBOSE: show entities labels as well as URIs.')
 @click.option('--web', '-w', is_flag=True, help='WEB: import ontologies from remote repositories.')
+@click.option('--shell', '-z', is_flag=True, help='SHELL: launch the interactive shell.')
 @click.pass_context
-def main_cli(ctx, sources=None, library=False, verbose=False, save=False, bootstrap=False, web=False, cache=False, update=False, delete=False, reset=False, endpoint=False):
+def main_cli(ctx, sources=None, library=False, verbose=False, save=False, bootstrap=False, web=False, shell=False, cache=False, update=False, delete=False, reset=False, endpoint=False):
     """
 Ontospy is a command line inspector for RDF/OWL knowledge models.
 
@@ -164,6 +165,10 @@ More info: <ontospy.readthedocs.org>
     elif web:
         action_webimport()
         # raise SystemExit(1)
+
+    elif shell:
+        from extras.shell import launch_shell
+        launch_shell(sources)
 
     else:
         if sources or (sources and endpoint):

--- a/ontospy/tests/test_load_local.py
+++ b/ontospy/tests/test_load_local.py
@@ -43,7 +43,7 @@ class TestLoadOntologies(unittest.TestCase):
 				o.printClassTree()
 				print("----------")
 
-				for c in o.classes:
+				for c in o.all_classes:
 					c.describe()
 
 				for p in o.properties:

--- a/ontospy/tests/test_load_local.py
+++ b/ontospy/tests/test_load_local.py
@@ -17,8 +17,6 @@ from ..core import *
 from ..core.utils import *
 
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-DATA_FOLDER = dir_path + "/rdf/"
 
 # sanity check
 print("-------------------\nOntoSpy ",  VERSION, "\n-------------------")
@@ -26,18 +24,20 @@ print("-------------------\nOntoSpy ",  VERSION, "\n-------------------")
 
 class TestLoadOntologies(unittest.TestCase):
 
+	dir_path = os.path.dirname(os.path.realpath(__file__))
+	DATA_FOLDER = dir_path + "/rdf/"
 
 	def test1_load_locally(self):
 		"""
 		Check if the ontologies in /RDF folder load ok
 		"""
-		print("=================\nTEST 1: Loading ontologies from <%s> folder and printing detailed entities descriptions.\n=================" % DATA_FOLDER)
+		print("=================\nTEST 1: Loading ontologies from <%s> folder and printing detailed entities descriptions.\n=================" % self.DATA_FOLDER)
 
-		for f in os.listdir(DATA_FOLDER):
+		for f in os.listdir(self.DATA_FOLDER):
 			if not f.startswith('.'):
 				printDebug("\n*****\nTest: loading local file... > %s\n*****" % str(f), "important")
 
-				o = Ontospy(DATA_FOLDER + f, verbose=True)
+				o = Ontospy(self.DATA_FOLDER + f, verbose=True)
 
 				print("CLASS TREE")
 				o.printClassTree()
@@ -52,7 +52,6 @@ class TestLoadOntologies(unittest.TestCase):
 				for s in o.skosConcepts:
 					s.describe()
 
-				# self.assertEqual(type(o), ontospy.Ontology)
 
 				print("Success.\n")
 

--- a/ontospy/tests/test_load_local.py
+++ b/ontospy/tests/test_load_local.py
@@ -49,7 +49,7 @@ class TestLoadOntologies(unittest.TestCase):
 				for p in o.all_properties:
 					p.describe()
 
-				for s in o.skosConcepts:
+				for s in o.all_skos_concepts:
 					s.describe()
 
 

--- a/ontospy/tests/test_load_local.py
+++ b/ontospy/tests/test_load_local.py
@@ -46,7 +46,7 @@ class TestLoadOntologies(unittest.TestCase):
 				for c in o.all_classes:
 					c.describe()
 
-				for p in o.properties:
+				for p in o.all_properties:
 					p.describe()
 
 				for s in o.skosConcepts:

--- a/ontospy/tests/test_methods.py
+++ b/ontospy/tests/test_methods.py
@@ -5,11 +5,12 @@ Unit test stub for ontosPy
 
 Run like this:
 
-:path/to/ontospyProject>python -m ontospy.tests.test_load_local
+:path/to/ontospyProject>python -m ontospy.tests.test_methods
 
 """
 
 from __future__ import print_function
+import click 
 
 import unittest, os, sys
 from .. import *
@@ -17,43 +18,68 @@ from ..core import *
 from ..core.utils import *
 
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-DATA_FOLDER = dir_path + "/rdf/"
-
 # sanity check
 print("-------------------\nOntoSpy ",  VERSION, "\n-------------------")
 
 
-class TestLoadOntologies(unittest.TestCase):
+class TestMethods(unittest.TestCase):
 
+	# updated 2018-05-08
 
-	def test1_load_locally(self):
+	dir_path = os.path.dirname(os.path.realpath(__file__))
+	DATA_FOLDER = dir_path + "/rdf/"
+	f = DATA_FOLDER + "pizza.ttl"
+	o = Ontospy(f, verbose=True)
+
+	printDebug("\n*****\nTest: loading with local file... > %s\n*****" % str(f), "important")
+
+	def test1(self):
 		"""
-		Check if the ontologies in /RDF folder load ok
+		Instances method
 		"""
-		print("=================\nTEST 1: Loading ontologies from <%s> folder and printing detailed entities descriptions.\n=================" % DATA_FOLDER)
+		printDebug("\n=================\nTEST 1: Checking the <instances> method", "green")
 
-		for f in os.listdir(DATA_FOLDER):
-			if not f.startswith('.'):
-				printDebug("\n*****\nTest: loading local file... > %s\n*****" % str(f), "important")
-
-				o = Ontospy(DATA_FOLDER + f, verbose=True)
-
-				print("CLASS TREE")
-				o.printClassTree()
-				print("----------")
-
-				for c in o.classes:
-					c.describe()
-
-				for p in o.properties:
-					p.describe()
-
-				for s in o.skosConcepts:
-					s.describe()
+		for c in self.o.classes:
+			# c.describe()
+			if c.instances:
+				print("CLASS: " + c.uri)
+				print("INSTANCES: ")
+				for el in c.instances:
+					print(el.uri, el.qname)
+					print(el.getValuesForProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
 
 
-				print("Success.\n")
+	def test2(self):
+		"""
+		getValuesForProperty
+		"""
+		printDebug("\n=================\nTEST 2: Checking the <getValuesForProperty> method", "green")
+
+		for c in self.o.classes[:3]:
+			print("CLASS: ")
+			print(c.uri, c.qname)
+			print("RDF:TYPE VALUES: ")
+			print(c.getValuesForProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+
+
+	
+	def test3(self):
+		"""
+		extract_entity_from_uri
+		"""
+		printDebug("\n=================\nTEST 2: Checking the <extract_entity_from_uri> method", "green")
+
+		e = self.o.extract_entity_from_uri("http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany")
+		print("URI: ", e)
+		print("RDFTYPE: ", e.rdftype)
+		print("BEST LABEL: ", e.bestLabel())
+		print("RDF SOURCE: ")
+		print(e.serialize())
+
+
+	
+	
+	print("Success.\n")
 
 
 

--- a/ontospy/tests/test_methods.py
+++ b/ontospy/tests/test_methods.py
@@ -74,7 +74,7 @@ class TestMethods(unittest.TestCase):
 		print("RDFTYPE: ", e.rdftype)
 		print("BEST LABEL: ", e.bestLabel())
 		print("RDF SOURCE: ")
-		print(e.serialize())
+		print(e.rdf_source())
 
 
 	

--- a/ontospy/tests/test_methods.py
+++ b/ontospy/tests/test_methods.py
@@ -52,7 +52,6 @@ class TestLoadOntologies(unittest.TestCase):
 				for s in o.skosConcepts:
 					s.describe()
 
-				# self.assertEqual(type(o), ontospy.Ontology)
 
 				print("Success.\n")
 

--- a/ontospy/tests/test_methods.py
+++ b/ontospy/tests/test_methods.py
@@ -65,11 +65,11 @@ class TestMethods(unittest.TestCase):
 	
 	def test3(self):
 		"""
-		extract_entity_from_uri
+		build_entity_from_uri
 		"""
-		printDebug("\n=================\nTEST 2: Checking the <extract_entity_from_uri> method", "green")
+		printDebug("\n=================\nTEST 2: Checking the <build_entity_from_uri> method", "green")
 
-		e = self.o.extract_entity_from_uri("http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany")
+		e = self.o.build_entity_from_uri("http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany")
 		print("URI: ", e)
 		print("RDFTYPE: ", e.rdftype)
 		print("BEST LABEL: ", e.bestLabel())

--- a/ontospy/tests/test_methods.py
+++ b/ontospy/tests/test_methods.py
@@ -39,7 +39,7 @@ class TestMethods(unittest.TestCase):
 		"""
 		printDebug("\n=================\nTEST 1: Checking the <instances> method", "green")
 
-		for c in self.o.classes:
+		for c in self.o.all_classes:
 			# c.describe()
 			if c.instances:
 				print("CLASS: " + c.uri)
@@ -55,7 +55,7 @@ class TestMethods(unittest.TestCase):
 		"""
 		printDebug("\n=================\nTEST 2: Checking the <getValuesForProperty> method", "green")
 
-		for c in self.o.classes[:3]:
+		for c in self.o.all_classes[:3]:
 			print("CLASS: ")
 			print(c.uri, c.qname)
 			print("RDF:TYPE VALUES: ")

--- a/ontospy/tests/test_quick.py
+++ b/ontospy/tests/test_quick.py
@@ -46,11 +46,11 @@ class TestQuick(unittest.TestCase):
 		"""
 		print("=================\nQUICK TEST 1 **************")
 
-		e = self.o.extract_entity_from_uri("http://www.co-ode.org/ontologies/pizza/non")
+		e = self.o.extract_entity_from_uri("http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany")
 
 		print(e)
 		print(e.bestLabel())
-		print(e.serialize())
+		print(e.rdf_source())
 
 
 if __name__ == "__main__":

--- a/ontospy/tests/test_quick.py
+++ b/ontospy/tests/test_quick.py
@@ -3,9 +3,11 @@
 """
 Unit test stub for ontosPy
 
-Run like this:
+Test Quick: use this file to quickly run scripts/tests which will then be integrated into proper tests
 
-:path/to/ontospyProject>python -m ontospy.tests.test_load_local
+Running it:
+
+./run-quick-test.sh
 
 """
 
@@ -17,33 +19,39 @@ from ..core import *
 from ..core.utils import *
 
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-DATA_FOLDER = dir_path + "/rdf/"
-
 # sanity check
 print("-------------------\nOntoSpy ",  VERSION, "\n-------------------")
 
 
 class TestQuick(unittest.TestCase):
 
+	dir_path = os.path.dirname(os.path.realpath(__file__))
+	DATA_FOLDER = dir_path + "/rdf/"
+	f = DATA_FOLDER + "pizza.ttl"
+	o = Ontospy(f, verbose=True)
 
-	def test_quick(self):
+	printDebug("\n*****\nTest: loading local file... > %s\n*****" % str(f), "important")
+
+	def test_quick0(self):
 		"""
 
 		"""
-		print("=================\nQUICK TEST **************")
+		print("=================\nQUICK TEST 0 **************")
+		# just showing how to accumulate tests
 
-		f = DATA_FOLDER + "pizza.ttl"
-		printDebug("\n*****\nTest: loading local file... > %s\n*****" % str(f), "important")
 
-		o = Ontospy(f, verbose=True)
+	def test_quick1(self):
+		"""
 
-		for c in o.classes:
-			# c.describe()
-			if c.instances:
-				for el in c.instances:
-					print(el.uri, el.qname)
-					print(el.getValuesForProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+		"""
+		print("=================\nQUICK TEST 1 **************")
+
+		e = self.o.extract_entity_from_uri("http://www.co-ode.org/ontologies/pizza/non")
+
+		print(e)
+		print(e.bestLabel())
+		print(e.serialize())
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/ontospy/tests/test_quick.py
+++ b/ontospy/tests/test_quick.py
@@ -46,7 +46,7 @@ class TestQuick(unittest.TestCase):
 		"""
 		print("=================\nQUICK TEST 1 **************")
 
-		e = self.o.extract_entity_from_uri("http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany")
+		e = self.o.build_entity_from_uri("http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany")
 
 		print(e)
 		print(e.bestLabel())

--- a/ontospy/tests/test_quick.py
+++ b/ontospy/tests/test_quick.py
@@ -39,10 +39,11 @@ class TestQuick(unittest.TestCase):
 		o = Ontospy(f, verbose=True)
 
 		for c in o.classes:
-			c.describe()
+			# c.describe()
 			if c.instances:
 				for el in c.instances:
 					print(el.uri, el.qname)
+					print(el.getValuesForProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
 
 if __name__ == "__main__":
 	unittest.main()

--- a/ontospy/tests/test_shapes.py
+++ b/ontospy/tests/test_shapes.py
@@ -40,12 +40,12 @@ class TestShapes(unittest.TestCase):
 		for el in o.stats():
 			print("%s : %d" % (el[0], el[1]))
 
-		for s in o.shapes:
+		for s in o.all_shapes:
 			printDebug("\nSHAPE: %s" % str(s), "green")
 			if s.targetClasses:
 				for x in s.targetClasses:
 					print(".....hasTargetClass: " + str(x))
-					print("     Reverse link: the class has %d associated shape." % len(x.shapes))
+					print("     Reverse link: the class has %d associated shape." % len(x.all_shapes))
 			else:
 				print("..... has no target class!")
 

--- a/ontospy/tests/test_shapes.py
+++ b/ontospy/tests/test_shapes.py
@@ -21,11 +21,11 @@ from ..core.utils import *
 # sanity check
 print("-------------------\nOntoSpy ",  VERSION, "\n-------------------")
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-DATA_FOLDER = dir_path + "/shapes/"
-
-
 class TestShapes(unittest.TestCase):
+
+
+	dir_path = os.path.dirname(os.path.realpath(__file__))
+	DATA_FOLDER = dir_path + "/shapes/"
 
 
 	def test1_local_shapes(self):
@@ -33,9 +33,9 @@ class TestShapes(unittest.TestCase):
 		"""
 		Check if the shapes in the SciGraph onto are loaded properly
 		"""
-		printDebug("=================\nTEST: Loading ontology & shapes from <%s> folder and printing summary.\n=================" % DATA_FOLDER, "important")
+		printDebug("=================\nTEST: Loading ontology & shapes from <%s> folder and printing summary.\n=================" % self.DATA_FOLDER, "important")
 
-		o = Ontospy(DATA_FOLDER, verbose=False)
+		o = Ontospy(self.DATA_FOLDER, verbose=False)
 
 		for el in o.stats():
 			print("%s : %d" % (el[0], el[1]))

--- a/ontospy/tests/test_sparql.py
+++ b/ontospy/tests/test_sparql.py
@@ -22,11 +22,10 @@ from ..core.utils import *
 print("-------------------\nOntoSpy ",  VERSION, "\n-------------------")
 
 
-ENDPOINT = "http://dbpedia.org/sparql"
-# ENDPOINT = "http://192.168.1.64:7200/repositories/scigraph-test"
 
 class TestSparqlStore(unittest.TestCase):
 
+    ENDPOINT = "http://dbpedia.org/sparql"
 
     def test1_load_dbpedia(self):
 
@@ -34,9 +33,9 @@ class TestSparqlStore(unittest.TestCase):
         Check if the dbpedia endpoint loads ok
         "http://dbpedia.org/sparql"
         """
-        printDebug("=================\nTEST: Loading <%s> endpoint.\n=================" % ENDPOINT, "important")
+        printDebug("=================\nTEST: Loading <%s> endpoint.\n=================" % self.ENDPOINT, "important")
 
-        o = Ontospy(sparql_endpoint=ENDPOINT, verbose=True)
+        o = Ontospy(sparql_endpoint=self.ENDPOINT, verbose=True)
 
         print(o), print("---------")
 

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -12,7 +12,6 @@ echo "=================="
 sleep 2
 python -m ontospy.tests.test_load_local
 
-
 echo ""
 echo "=================="
 echo "CALLING [test_load_remote] in 5 seconds..."

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -14,6 +14,13 @@ python -m ontospy.tests.test_load_local
 
 echo ""
 echo "=================="
+echo "CALLING [test_methods] in 5 seconds..."
+echo "=================="
+sleep 2
+python -m ontospy.tests.test_methods
+
+echo ""
+echo "=================="
 echo "CALLING [test_load_remote] in 5 seconds..."
 echo "=================="
 sleep 2

--- a/run-quick-test.sh
+++ b/run-quick-test.sh
@@ -7,9 +7,9 @@
 clear
 
 echo "=================="
-echo "CALLING [test_quick] in 2 seconds..."
+echo "CALLING [test_quick] in 1 second..."
 echo "=================="
-sleep 2
+sleep 1
 python -m ontospy.tests.test_quick
 
 

--- a/run-shell.sh
+++ b/run-shell.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# simple script to run iPython preloaded with this library
+# prerequisites: chmod u+x run-shell.sh
+
+clear
+
+echo "=================="
+echo "Opening iPython with Ontospy pre-loaded..."
+echo "=================="
+ipython shell_profile.py --no-simple-prompt --no-confirm-exit -i

--- a/shell_profile.py
+++ b/shell_profile.py
@@ -1,0 +1,4 @@
+# startup file for ipython
+# $ ipython startup.py -i
+
+from ontospy import *


### PR DESCRIPTION
Refactoring method names:
* all 'extract_' methods renamed as 'build_' renamed as extract_all 
* build_entity_from_uri: extract all triples for a specific URI (even if not in model) and instantiate RDF_Entity() so that it can be queried further  
* x.rdfgraph renamed as x.rdflib_graph 
* x.serialize renamed as x.rdf_source
* tidy up all tests code
* ontospy properties returning entities: all renamed using the all_* pattern eg all_classes etc..