### PR TITLE
Add non-redundant-tree logic for ontodocs

### DIFF
--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -950,7 +950,7 @@ class Ontospy(object):
                 flag = True
         return None
 
-    def ontologyClassTree(self):
+    def ontologyClassTree(self, repeatChildren=True):
         """
         Returns a dict representing the ontology tree
         Top level = {0:[top classes]}
@@ -960,12 +960,20 @@ class Ontospy(object):
         if self.all_classes:
             treedict[0] = self.toplayer_classes
             for element in self.all_classes:
-                if element.children():
-                    treedict[element] = element.children()
+                if repeatChildren:
+                    if element.children():
+                        treedict[element] = element.children()
+                else:
+                    treedict[element] = list()
+                    children_set = set(element.children())
+                    for e in element.children():
+                        parents_set = set(e.parents())
+                        if not children_set.intersection(parents_set):
+                            treedict[element].append(e)
             return treedict
         return treedict
 
-    def ontologyPropTree(self):
+    def ontologyPropTree(self, repeatChildren=True):
         """
         Returns a dict representing the ontology tree
         Top level = {0:[top properties]}
@@ -975,12 +983,20 @@ class Ontospy(object):
         if self.all_properties:
             treedict[0] = self.toplayer_properties
             for element in self.all_properties:
-                if element.children():
-                    treedict[element] = element.children()
+                if repeatChildren:
+                    if element.children():
+                        treedict[element] = element.children()
+                else:
+                    treedict[element] = list()
+                    children_set = set(element.children())
+                    for e in element.children():
+                        parents_set = set(e.parents())
+                        if not children_set.intersection(parents_set):
+                            treedict[element].append(e)
             return treedict
         return treedict
 
-    def ontologyConceptTree(self):
+    def ontologyConceptTree(self, repeatChildren=True):
         """
         Returns a dict representing the skos tree
         Top level = {0:[top concepts]}
@@ -990,8 +1006,16 @@ class Ontospy(object):
         if self.all_skos_concepts:
             treedict[0] = self.toplayer_skos
             for element in self.all_skos_concepts:
-                if element.children():
-                    treedict[element] = element.children()
+                if repeatChildren:
+                    if element.children():
+                        treedict[element] = element.children()
+                else:
+                    treedict[element] = list()
+                    children_set = set(element.children())
+                    for e in element.children():
+                        parents_set = set(e.parents())
+                        if not children_set.intersection(parents_set):
+                            treedict[element].append(e)
             return treedict
         return treedict
 


### PR DESCRIPTION
Hello (Michele, a.k.a. @lambdamusic). Please, consider the integration of this PR into Ontospy.

## In a nutshell
This PR allows the generation of ontologyClassTrees, ontologyPropTrees, ontologyConceptTrees without repeating redundant sub-entities along the hierarchy. It display a "distinct" taxonomy without repetitions. Multi-inheritance (i.e., a class inheriting from diverse classes) is preserved.

### Application
Useful when you need to represent trees of full reasoned ontologies (e.g., when you load the ontology from the SPARQL endpoint of Ontotext's GraphDB with reasoning enabled). In those cases new implicit triples are inferred and added to the knowledge graph (e.g., due to the transitivity of properties like` rdfs:subClassOf`) but you might not want to visualize all implicit sub-*-classes relations in the ontodocs trees.

### Rationale
Rule introduced:
- add a child **c** to an entity **e** iif  (i) **c** is a child of **e** and (ii) parents of **e**  are not childern of **c**.

## Full story
Let's start from this ontology
```sparql
@prefix : <http://theRed-beardedOntology#> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .


#################################################################
#    Classes
#################################################################


:Mammal rdf:type owl:Class .

:Human rdf:type owl:Class ;
       rdfs:subClassOf :Mammal .

:Red-beardedGuy rdf:type owl:Class ;
                rdfs:subClassOf :Human .

```

`:Mammal` is subclassed by `:Human` that is subclassed by `:Red-beardedGuy`. If this ontology is reasoned with common rulesets, the following triple is materialized:

```sparql
:Red-beardedGuy rdfs:subClassOf :Mammal .
```

Now, if we call the legacy version of `ontologyClassTrees`, we would get this tree in the ontology doc:

```
http://theRed-beardedOntology#Mammal
|       http://theRed-beardedOntology#Human
|       |        http://theRed-beardedOntology#Red-beardedGuy
|       http://theRed-beardedOntology#Red-beardedGuy
```
...and it's perfectly fine. Indeed, `:Red-beardedGuy` is a sub-class both of `:Mammal` and of `:Human`. However, this representation could be pretty redundant for some uses. A kind of "distinct" taxonomy like this one is desirable:

```
http://theRed-beardedOntology#Mammal
|       http://theRed-beardedOntology#Human
|       |        http://theRed-beardedOntology#Red-beardedGuy
```

and it makes much more sense to the reader. : )

To get this, I introduced the arg `repeatChildren` in the tree methods of the class `Ontospy` (it defaults to `True` for backward compatibility). It `repeatChildren` is set to `False`, you get the non-redundant tree version.

Let me know your reactions as you go through it.

> Ciao Michele, e grazie per questo bel lavoro che metti a disposizione qui su GitHub!



