### PR TITLE
Improving Ontodocs to display concepts labels instead of URIs

### DIFF
--- a/ontospy/ontodocs/media/templates/html-multi/browser/browser_classinfo.html
+++ b/ontospy/ontodocs/media/templates/html-multi/browser/browser_classinfo.html
@@ -42,7 +42,7 @@
 
             <h1>
 {#                Class: #}
-                {{each.qname}}
+                {{each.bestLabel}}
                 {% if not each.children  %}
                     <small class="label label-info label-xs">leaf node</small>
                   {% endif %}
@@ -61,14 +61,14 @@
 
                         <li>
 
-                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a>
+                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a>
 
                           <ul>
 
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -83,11 +83,11 @@
                         <li><a href="entities-tree-classes.html">owl:Thing</a>
 
                           <ul>
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
 
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -158,7 +158,7 @@
             <div class="panel-body">
 
             {% if each.ancestors %}
-                    {% for s in each.ancestors %}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.qname}}</a></li>{% endfor %}
+                    {% for s in each.ancestors %}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.bestLabel}}</a></li>{% endfor %}
             {% else %}
                 <li>owl:Thing</li>
             {% endif %}
@@ -179,7 +179,7 @@
            <div class="panel-body">
 
 
-             {% for s in each.all_shapes%}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.qname}}</a></li>{% endfor %}
+             {% for s in each.all_shapes%}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.bestLabel}}</a></li>{% endfor %}
 
 
            </div>
@@ -197,7 +197,7 @@
             </div>
             <div class="panel-body" style="overflow: auto;">
 
-                <p>Instances of {{each.qname}} can have the following properties:</p>
+                <p>Instances of {{each.bestLabel}} can have the following properties:</p>
             </div>
              <table class="table table-bordered" style="overflow: auto;">
 
@@ -212,14 +212,14 @@
                     {% if v %}
 
                         <tr class="table-inheritanceinfo">
-                            <th colspan="4" class="treeinfo"><span class="label label-default">From class <a title="{{k.qname}}" href="{{k.slug}}.html" class="fromclass_link">{{k.qname}}</a></span>
+                            <th colspan="4" class="treeinfo"><span class="label label-default">From class <a title="{{k.qname}}" href="{{k.slug}}.html" class="fromclass_link">{{k.bestLabel}}</a></span>
                             </th>
                         </tr>
 
                             {% for prop in v  %}
                             <tr>
                                 <td class="firsttd">
-                                    <a class="propcolor" title="{{prop.qname}}" href="{{prop.slug}}.html">{{prop.qname}}</a>
+                                    <a class="propcolor" title="{{prop.qname}}" href="{{prop.slug}}.html">{{prop.bestLabel}}</a>
                                 </td>
                                 <td class="secondtd">
                                     <i>{{prop.rdftype_qname}}<i>
@@ -232,9 +232,9 @@
                                     {% for range in prop.ranges  %}
 
                                         {% if not range.ext_model %}
-                                          <a title="{{range.qname}}" href="{{range.slug}}.html" class="rdfclass">{{range.qname}}</a>
+                                          <a title="{{range.qname}}" href="{{range.slug}}.html" class="rdfclass">{{range.bestLabel}}</a>
                                         {% else %}
-                                          <i>{{range.qname}}</i>
+                                          <i>{{range.bestLabel}}</i>
                                         {% endif %}
 
 

--- a/ontospy/ontodocs/media/templates/html-multi/browser/browser_conceptinfo.html
+++ b/ontospy/ontodocs/media/templates/html-multi/browser/browser_conceptinfo.html
@@ -40,7 +40,7 @@
 
          <h1>
 {#                Concept: #}
-             {{each.qname}}
+             {{each.bestLabel}}
              {% if not each.children  %}
                  <small class="label label-info label-xs ">leaf node</small>
                {% endif %}
@@ -61,14 +61,14 @@
 
                         <li>
 
-                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a>
+                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a>
 
                           <ul>
 
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -83,11 +83,11 @@
                         <li><a href="entities-tree-properties.html">skos:Concept</a>
 
                           <ul>
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
 
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -161,7 +161,7 @@
             <div class="panel-body">
 
             {% if each.ancestors %}
-                    {% for s in each.ancestors %}<li><a href="{{s.slug}}.html">{{s.qname}}</a></li>{% endfor %}
+                    {% for s in each.ancestors %}<li><a href="{{s.slug}}.html">{{s.bestLabel}}</a></li>{% endfor %}
             {% else %}
                 <li>owl:Thing</li>
             {% endif %}

--- a/ontospy/ontodocs/media/templates/html-multi/browser/browser_entities_az.html
+++ b/ontospy/ontodocs/media/templates/html-multi/browser/browser_entities_az.html
@@ -57,7 +57,7 @@
                <dl>
 
                {% for each in ontospy_graph.all_classes %}
-                   <dt><a href="{{each.slug}}.html">{{each.qname}}</a></dt>
+                   <dt><a href="{{each.slug}}.html">{{each.bestLabel}}</a></dt>
                    <dd>
 {#                       {{ each.bestDescription|default:"[no definition]" }}#}
                    </dd>
@@ -120,7 +120,7 @@
                    <dl>
 
                    {% for each in ontospy_graph.all_properties  %}
-                       <dt><a href="{{each.slug}}.html">{{each.qname}}</a></dt>
+                       <dt><a href="{{each.slug}}.html">{{each.bestLabel}}</a></dt>
                        <dd>
 {#                           {{ each.bestDescription|default:"[no definition]" }}#}
                        </dd>

--- a/ontospy/ontodocs/media/templates/html-multi/browser/browser_propinfo.html
+++ b/ontospy/ontodocs/media/templates/html-multi/browser/browser_propinfo.html
@@ -36,7 +36,7 @@
 
             <h1>
 {#                Property: #}
-                {{each.qname}}
+                {{each.bestLabel}}
                 {% if not each.children  %}
                     <small class="label label-info label-xs ">leaf node</small>
                   {% endif %}
@@ -56,14 +56,14 @@
 
                         <li>
 
-                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a>
+                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a>
 
                           <ul>
 
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -78,11 +78,11 @@
                         <li><a href="entities-tree-properties.html">rdf:Property</a>
 
                           <ul>
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
 
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -154,7 +154,7 @@
                     <div class="panel-body">
 
                     {% if each.ancestors %}
-                            {% for s in each.ancestors %}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.qname}}</a></li>{% endfor %}
+                            {% for s in each.ancestors %}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.bestLabel}}</a></li>{% endfor %}
                     {% else %}
                         <li>owl:Thing</li>
                     {% endif %}
@@ -176,7 +176,7 @@
                   </div>
                   <div class="panel-body">
 
-                      {% for s in each.children %}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.qname}}</a></li>{% endfor %}
+                      {% for s in each.children %}<li><a href="{{s.slug}}.html" title="{{s.uri}}">{{s.bestLabel}}</a></li>{% endfor %}
 
 
                   </div>
@@ -202,11 +202,11 @@
                      {% if each.domains %}
                          {% for s in each.domains %}
                          {% if s.ext_model %}
-                              <a href="{{s.uri}}" target="_blank" title="{{s.uri}}">{{s.qname|default:s}}</a>
+                              <a href="{{s.uri}}" target="_blank" title="{{s.uri}}">{{s.bestLabel|default:s}}</a>
                            {% elif s.is_Bnode  %}
                               <a>Blank node</a> (see implementation)
                            {% else  %}
-                              <a href="{{s.slug}}.html" title="{{s.uri}}">{{s.qname|default:s}}</a>
+                              <a href="{{s.slug}}.html" title="{{s.uri}}">{{s.bestLabel|default:s}}</a>
                            {% endif %}
                            {% if not forloop.last %}, {% endif %}
                          {% endfor %}
@@ -216,18 +216,18 @@
                    </td>
 
                     <td>
-                      {{each.qname}}
+                      {{each.bestLabel}}
                     </td>
 
                     <td>
                       {% if each.ranges %}
                           {% for s in each.ranges %}
                           {% if s.ext_model %}
-                               <a href="{{s.uri}}" target="_blank" title="{{s.uri}}">{{s.qname|default:s}}</a>
+                               <a href="{{s.uri}}" target="_blank" title="{{s.uri}}">{{s.bestLabel|default:s}}</a>
                              {% elif s.is_Bnode  %}
                                 <a>Blank node</a> (see implementation)
                             {% else  %}
-                               <a href="{{s.slug}}.html" title="{{s.uri}}">{{s.qname|default:s}}</a>
+                               <a href="{{s.slug}}.html" title="{{s.uri}}">{{s.bestLabel|default:s}}</a>
                             {% endif %}
                             {% if not forloop.last %}, {% endif %}
                           {% endfor %}

--- a/ontospy/ontodocs/media/templates/html-multi/browser/browser_shapeinfo.html
+++ b/ontospy/ontodocs/media/templates/html-multi/browser/browser_shapeinfo.html
@@ -42,7 +42,7 @@
 
             <h1>
 {#                Class: #}
-                {{each.qname}}
+                {{each.bestLabel}}
                 {% if not each.children  %}
                     <small class="label label-info label-xs">leaf node</small>
                   {% endif %}
@@ -61,14 +61,14 @@
 
                         <li>
 
-                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a>
+                          <a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a>
 
                           <ul>
 
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -83,11 +83,11 @@
                         <li><a href="entities-tree-classes.html">sh:Shape</a>
 
                           <ul>
-                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.qname}}</a>
+                            <li><a style="font-weight: bold;" title="'{{each.bestLabel}}'{% if each.bestDescription %} - {{each.bestDescription|truncatewords:20}}{% endif %}">{{each.bestLabel}}</a>
 
                             {% if each.children  %}
                                 <ul>
-                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.qname}}</a></li>{% endfor %}
+                                  {% for s in each.children %}<li><a href="{{s.slug}}.html" title="'{{s.bestLabel}}'{% if s.bestDescription %} - {{s.bestDescription|truncatewords:20}}{% endif %}">{{s.bestLabel}}</a></li>{% endfor %}
                                 </ul>
                             {% endif %}
                               </li>
@@ -158,7 +158,7 @@
             <div class="panel-body">
 
             {% if each.ancestors %}
-                    {% for s in each.ancestors %}<li><a href="{{s.slug}}.html">{{s.qname}}</a></li>{% endfor %}
+                    {% for s in each.ancestors %}<li><a href="{{s.slug}}.html">{{s.bestLabel}}</a></li>{% endfor %}
             {% else %}
                 <li>owl:Thing</li>
             {% endif %}
@@ -177,7 +177,7 @@
             </div>
             <div class="panel-body">
 
-              {% for s in each.targetClasses %}<li><a href="{{s.slug}}.html">{{s.qname}}</a></li>{% endfor %}
+              {% for s in each.targetClasses %}<li><a href="{{s.slug}}.html">{{s.bestLabel}}</a></li>{% endfor %}
 
 
             </div>

--- a/ontospy/ontodocs/utils.py
+++ b/ontospy/ontodocs/utils.py
@@ -206,7 +206,7 @@ def formatHTML_EntityTreeTable(treedict, element=0):
         else:
             stringa += """<tr>
 							<td class="tc" colspan=4><a title=\"%s\" class=\"treelinks\" href=\"%s.html\">%s</a></td>
-						  </tr>""" % (x.uri, x.slug, truncchar_inverse(x.qname, 50))
+						  </tr>""" % (x.uri, x.slug, truncchar_inverse(x.bestLabel(quotes=False), 70))
 
         if treedict.get(x, None):
             stringa += """ <tr>


### PR DESCRIPTION
Improvement already mentioned in this issue: https://github.com/lambdamusic/Ontospy/issues/82

Example of an ontology docs generated using this new version: https://vemonet.github.io/semanticscience/browse/entities-tree-classes.html

I mostly replaced `.qname` by `.bestLabel` in the links rendering in the templates (and `utils.py` for the classes tree)

Thanks a lot for `ontospy`, it's a really useful and easy to use tool for ontology manipulation!