### PR TITLE
Remove retired package rdflib-jsonld from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-rdflib>=4.2.1
-rdflib-jsonld>=0.4.0
+rdflib>=6.0.0
 SPARQLWrapper>=1.8.0
 html5lib>=1.0.1
 requests>=2.20.0


### PR DESCRIPTION
RDFLib folded the `rdflib-jsonld` package into the `rdflib` package in
July.  The repository has also since been put into an "archived" state:
https://github.com/RDFLib/rdflib-jsonld/

Unfortunately, some time recently, including `rdflib-jsonld` in a build
causes the build to break, as it uses a `2to3` function in some manner
that raises an error.

This patch updates Ontospy's requirements to maintain the RDFLib JSON-LD
functionality import, by requiring rdflib>=6.0.0 (the version that
integrated the JSON-LD package).

Disclaimer:
Participation by NIST in the creation of the documentation of mentioned
software is not intended to imply a recommendation or endorsement by the
National Institute of Standards and Technology, nor is it intended to
imply that any specific software is necessarily the best available for
the purpose.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>