### PR TITLE
Add Continuous Integration to assist with code review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+# This workflow runs the repository's defined unit tests.
+
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Update package management
+      run: pip install --upgrade pip setuptools
+    - name: Install dependent packages
+      run: pip install click colorama rdflib requests
+    - name: Install test packages
+      run: pip install nose
+    - name: Run tests
+      run: nosetests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Update package management
-      run: pip install --upgrade pip setuptools
-    - name: Install dependent packages
-      run: pip install click colorama rdflib requests
+      run: pip install --upgrade pip setuptools wheel
+    - name: Install package and dependencies
+      run: pip install .
     - name: Install test packages
       run: pip install nose
     - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-rdflib>=4.2.1
-rdflib-jsonld>=0.4.0
+rdflib>=6.0.0
 SPARQLWrapper>=1.8.0
 html5lib>=1.0.1
 requests>=2.20.0


### PR DESCRIPTION
This patch series adds CI, making use of Github Actions.  Pull Requests
against the `master` branch will trigger CI and give an indicator of
whether there is a unit tests issue, before any manual review is needed.
(Asterisk: Github has started requiring first-time contributors get
their CI workflow approved to run, so there is one repo.-admin click to
do per user before the CI runs.)

Overall, this patch series is expected to reduce the amount of
round-trip communications between the project maintainer and pull
request submitters, as a submitter can handle automatically-discovered
build issues before requesting the maintainer's review.

Disclaimer:
Participation by NIST in the creation of the documentation of mentioned
software is not intended to imply a recommendation or endorsement by the
National Institute of Standards and Technology, nor is it intended to
imply that any specific software is necessarily the best available for
the purpose.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>