### PR TITLE
Adjust notion of "Top-level property" to account for SHACL shapes

### DIFF
--- a/ontospy/core/ontospy.py
+++ b/ontospy/core/ontospy.py
@@ -806,7 +806,8 @@ class Ontospy(object):
 
 			# add properties from Owl:Thing ie the inference layer
 
-			topLevelProps = [p for p in self.all_properties if p.domains == []]
+			properties_applicable_by_shapes = {x[0] for x in self.sparqlHelper.getPropsApplicableByShapes()}
+			topLevelProps = [p for p in self.all_properties if p.domains == [] and not p.uri in properties_applicable_by_shapes]
 			if topLevelProps:
 				_list.append({self.OWLTHING: topLevelProps})
 

--- a/ontospy/core/sparql_helper.py
+++ b/ontospy/core/sparql_helper.py
@@ -172,6 +172,28 @@ class SparqlHelper(object):
                  """ % (aURI))
         return list(qres)
 
+    def getPropsApplicableByShapes(self):
+        """
+            Find all properties that should not be "top-level" because they 
+            apply to some class via some SHACL PropertyShape.
+        """
+
+        qres = self.rdflib_graph.query("""SELECT ?nProperty
+                WHERE {
+                {
+                    ?nClass a rdfs:Class .
+                } UNION {
+                    ?nClass a owl:Class .
+                }
+
+                ?nNodeShape
+                    sh:property/sh:path ?nProperty ;
+                    sh:targetClass ?nClass ;
+                    .
+                }
+            """)
+        return list(qres)
+
     # ..................
     # SKOS
     # ..................

--- a/ontospy/core/sparql_helper.py
+++ b/ontospy/core/sparql_helper.py
@@ -180,18 +180,17 @@ class SparqlHelper(object):
 
         qres = self.rdflib_graph.query("""SELECT ?nProperty
                 WHERE {
-                {
-                    ?nClass a rdfs:Class .
-                } UNION {
-                    ?nClass a owl:Class .
+                        {
+                            { ?nClass a rdfs:Class . }
+                            UNION
+                            { ?nClass a owl:Class . }
+                        }
+                        ?nNodeShape
+                            sh:property/sh:path ?nProperty ;
+                            sh:targetClass ?nClass ;
+                            .
                 }
-
-                ?nNodeShape
-                    sh:property/sh:path ?nProperty ;
-                    sh:targetClass ?nClass ;
-                    .
-                }
-            """)
+                """)
         return list(qres)
 
     # ..................

--- a/ontospy/core/sparql_helper.py
+++ b/ontospy/core/sparql_helper.py
@@ -174,7 +174,7 @@ class SparqlHelper(object):
 
     def getPropsApplicableByShapes(self):
         """
-            Find all properties that should not be "top-level" because they 
+            Find all properties that should not be "top-level" because they
             apply to some class via some SHACL PropertyShape.
         """
 

--- a/ontospy/core/sparql_helper.py
+++ b/ontospy/core/sparql_helper.py
@@ -178,6 +178,12 @@ class SparqlHelper(object):
             apply to some class via some SHACL PropertyShape.
         """
 
+        # This query finds classes by explicit class statement, and
+        # infers the class being a SHACL Shape from the domain of
+        # sh:property.  From SHACL specification section 2.1.3.3,
+        # "Implicit Class Targets", a reflective sh:targetClass is
+        # implied.
+        # https://www.w3.org/TR/shacl/#implicit-targetClass
         qres = self.rdflib_graph.query("""SELECT ?nProperty
                 WHERE {
                         {
@@ -185,10 +191,7 @@ class SparqlHelper(object):
                             UNION
                             { ?nClass a owl:Class . }
                         }
-                        ?nNodeShape
-                            sh:property/sh:path ?nProperty ;
-                            sh:targetClass ?nClass ;
-                            .
+                        ?nClass sh:property/sh:path ?nProperty .
                 }
                 """)
         return list(qres)


### PR DESCRIPTION
This patch will address use cases where an ontology may define no or few rdfs:domain statements for its properties, instead relating properties to classes via SHACL shapes.  If a property is associated to classes via SHACL property shapes within an ontology, it does not seem appropriate to treat the property as universally applicable.

Contained is a new method in the _SparqlHelper_ class, which will find find the properties that should not be "top-level" due to applying to a class as a SHACL PropertyShape, and adjust the "Top-level property" based on this query.

Please advise if there is a better approach to solving this case where an ontology may utilize OWL, SHACL, or both.

