### PR TITLE
Expand tested Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version:
+        - 3.8
+        - 3.9
+        # - "3.11"  # TODO - Replace 3.9 reference with this line after nose issue settled.
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='ontology semantic web linked data rdf owl visualization documentation knowledge graph',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),


### PR DESCRIPTION
Python 3.7 is now past end of support.  The current versions available, and their end of support dates, are listed on the python.org downloads page.

This patch meant to expand testing to run CI against the oldest and most recent active Python releases.  However, `nose` (not updated since 2015) fails to run due to referencing `collections.Callable`, a construct present in Python 2.7, but absent from documentation since Python 3.3, and unable to be referenced starting in Python 3.10.

References:
* https://docs.python.org/2.7/library/collections.html
* https://docs.python.org/3.2/library/collections.html
* https://docs.python.org/3.3/library/collections.html
* https://www.python.org/downloads/