### PR TITLE
Don't use linebreaks filter in Markdown templates (#64)

### DIFF
--- a/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
@@ -40,7 +40,7 @@
 {{each.uri}}
 
 #### Description
-{{each.bestDescription()|linebreaks|default("--")}}
+{{each.bestDescription()|default("--")}}
 
 
 {% if each.ancestors() %}

--- a/ontospy/gendocs/media/templates/markdown/markdown_conceptinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_conceptinfo.md
@@ -40,7 +40,7 @@
 {{each.uri}}
 
 #### Description
-{{each.bestDescription()|linebreaks|default("--")}}
+{{each.bestDescription()|default("--")}}
 
 
 {% if each.ancestors() %}

--- a/ontospy/gendocs/media/templates/markdown/markdown_individualinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_individualinfo.md
@@ -13,7 +13,7 @@
 {{each.uri}}
 
 #### Description
-{{each.bestDescription()|linebreaks|default("--")}}
+{{each.bestDescription()|default("--")}}
 
 
 {% if each.instance_of %}

--- a/ontospy/gendocs/media/templates/markdown/markdown_propinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_propinfo.md
@@ -40,7 +40,7 @@
 {{each.uri}}
 
 #### Description
-{{each.bestDescription()|linebreaks|default("--")}}
+{{each.bestDescription()|default("--")}}
 
 {% if each.ancestors() %}
 #### Inherits from ({{ each.ancestors()|length }})


### PR DESCRIPTION
The Markdown Django templates were using the linebreaks filter on some of the content.  This filter wraps content using `<p>` and `<br />`. However this means that if the ontology was using Markdown in their comments this would not get rendered as most Markdown renderers don't apply rendering inside of HTML block elements like `<p>`.  It was also unnecessary since Markdown renderers already use line breaks to suitably render paragraphs.

This was most applicable for descriptions of things since those are the places were ontology authors were most likely to want to use Markdown to explain the intended usage of their ontology concepts.

By removing the use of this filter the ontology descriptions are output as-is in the generated Markdown files allowing any Markdown in them to be rendered by whatever Markdown renderer the user ultimately chooses.

This resolves #64