### PR TITLE
Fix tables markdown for classes in gendoc 

### DIFF
--- a/ontospy/core/__init__.py
+++ b/ontospy/core/__init__.py
@@ -6,7 +6,7 @@ from ..VERSION import __version__, VERSION
 import logging
 logging.basicConfig()
 
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 import sys, os
 import pickle as cPickle
 
@@ -56,8 +56,8 @@ BOOTSTRAP_ONTOLOGIES = [
 
 # sample endpoints
 BOOTSTRAP_ENDPOINTS = [
-    "http://dbpedia.org/sparql", 
+    "http://dbpedia.org/sparql",
     "http://data.semanticweb.org/sparql",
-    "http://linkedgeodata.org/sparql", 
+    "http://linkedgeodata.org/sparql",
     "http://sparql.data.southampton.ac.uk/"
 ]

--- a/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
@@ -73,14 +73,14 @@ owl:Thing
 #### Instances of {{each.title}} can have the following properties:
 
 {% for group in each.domain_of_inferred  %}      
-    {% for k,v in group.items()  -%}
+    {%- for k,v in group.items()  -%}
           
-From [{{k.title}}]({{k.slug}}.md):
+##### From [{{k.title}}]({{k.slug}}.md):
 
 | Property | Description | Expected Type |
 |----------|-------------|---------------|
 {% for prop in v -%}
-| [{{prop.title}}]({{prop.slug}}.md) | {{prop.bestDescription}} | 
+| [{{prop.title}}]({{prop.slug}}.md) | {{prop.bestDescription()}} | 
             {%- if  prop.ranges -%}
                 {%- for range in prop.ranges -%} 
 [{{range.title}}]({{range.slug}}.md)

--- a/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
@@ -73,49 +73,43 @@ owl:Thing
 #### Instances of {{each.title}} can have the following properties:
 
 <table border="1" cellspacing="3" cellpadding="5" class="classproperties table-hover ">
+<tr>
+   <th height="40">Property</th><th>Description</th><th>Expected Type</th>
+</tr>
 
-    <tr>
-        <th height="40">Property</th><th>Description</th><th>Expected Type</th>
-    </tr>
+{% for group in each.domain_of_inferred  %}      
+    {% for k,v in group.items()  %}
+          
+      
+<tr style="background: lightcyan;text-align: left;">
+   <th colspan="3" height="10" class="treeinfo"><span style="font-size: 80%;">
+   From <a title="{{k.qname}}" href="{{k.slug}}.md" class="rdfclass">{{k.title}}</a></span>
+   </th>
+</tr>       
 
-    {% for group in each.domain_of_inferred  %}      
-
-        {% for k,v in group.items()  %}
-            
-        
-        <tr style="background: lightcyan;text-align: left;">
-            <th colspan="3" height="10" class="treeinfo"><span style="font-size: 80%;">
-            From <a title="{{k.qname}}" href="{{k.slug}}.md" class="rdfclass">{{k.title}}</a></span>
-            </th>
-        </tr>       
-
-            {% for prop in v  %}
-            <tr>
-                <td class="firsttd">
-                    <a class="propcolor" title="{{prop.qname}}" href="{{prop.slug}}.md">{{prop.title}}</a>         
-                </td>
-                <td class="thirdtd">
-                    <span>{{prop.bestDescription}}</span>
-                </td>
-                <td class="secondtd">
-                    {% if  prop.ranges %}
-                    {% for range in prop.ranges  %}
-
-                        <a title="{{range.qname}}" href="{{range.slug}}.md" class="rdfclass">{{range.title}}</a>
-
-                    {% endfor %}
-                    {% else %}
-                        <i>owl:Thing</i>
-                    {% endif %}
-                </td>
-            </tr>
+          {% for prop in v  %}
+<tr>
+   <td class="firsttd">
+   <a class="propcolor" title="{{prop.qname}}" href="{{prop.slug}}.md">{{prop.title}}</a>         
+   </td>
+   <td class="thirdtd">
+   <span>{{prop.bestDescription}}</span>
+   </td>
+   <td class="secondtd">
+               {% if  prop.ranges %}
+                   {% for range in prop.ranges  %}
+   <a title="{{range.qname}}" href="{{range.slug}}.md" class="rdfclass">{{range.title}}</a>
+                   {% endfor %}
+               {% else %}
+  <i>owl:Thing</i>
+               {% endif %}
+   </td>
+</tr>
 
             {% endfor %}
 
-        {% endfor %}
-
-    {% endfor %}
-
+      {% endfor %}
+{% endfor %}
 </table>
 
 {% endif %}

--- a/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
+++ b/ontospy/gendocs/media/templates/markdown/markdown_classinfo.md
@@ -72,53 +72,30 @@ owl:Thing
 {% if each.domain_of_inferred %}
 #### Instances of {{each.title}} can have the following properties:
 
-<table border="1" cellspacing="3" cellpadding="5" class="classproperties table-hover ">
-<tr>
-   <th height="40">Property</th><th>Description</th><th>Expected Type</th>
-</tr>
-
 {% for group in each.domain_of_inferred  %}      
-    {% for k,v in group.items()  %}
+    {% for k,v in group.items()  -%}
           
-      
-<tr style="background: lightcyan;text-align: left;">
-   <th colspan="3" height="10" class="treeinfo"><span style="font-size: 80%;">
-   From <a title="{{k.qname}}" href="{{k.slug}}.md" class="rdfclass">{{k.title}}</a></span>
-   </th>
-</tr>       
+From [{{k.title}}]({{k.slug}}.md):
 
-          {% for prop in v  %}
-<tr>
-   <td class="firsttd">
-   <a class="propcolor" title="{{prop.qname}}" href="{{prop.slug}}.md">{{prop.title}}</a>         
-   </td>
-   <td class="thirdtd">
-   <span>{{prop.bestDescription}}</span>
-   </td>
-   <td class="secondtd">
-               {% if  prop.ranges %}
-                   {% for range in prop.ranges  %}
-   <a title="{{range.qname}}" href="{{range.slug}}.md" class="rdfclass">{{range.title}}</a>
-                   {% endfor %}
-               {% else %}
-  <i>owl:Thing</i>
-               {% endif %}
-   </td>
-</tr>
-
-            {% endfor %}
-
-      {% endfor %}
+| Property | Description | Expected Type |
+|----------|-------------|---------------|
+{% for prop in v -%}
+| [{{prop.title}}]({{prop.slug}}.md) | {{prop.bestDescription}} | 
+            {%- if  prop.ranges -%}
+                {%- for range in prop.ranges -%} 
+[{{range.title}}]({{range.slug}}.md)
+                {%- endfor -%}
+            {%- else -%} 
+*owl:Thing*
+            {%- endif -%} 
+|
 {% endfor %}
-</table>
+{% endfor %}
+{% endfor %}
 
 {% endif %}
 
 
-
 {% endif %}
-
-
-
 
 {% endblock main_column %}


### PR DESCRIPTION
Hello,

Thanks for this useful tool. This pull request proposes an update of the markdown template for classes in gendoc, with which I had some issues.

The first commit is simply removing some leading spaces that caused pandoc (as well as the github markdown renderer) to consider the subsequent HTML-formatted table as a code block, hence escaping the html tags and special characters, and causing the actual html code to be displayed instead of a table when rendered as html.

Then I tried to switch to the usual way to encode tables in markdown, thus avoiding the HTML tags. I had to tweak the jinja tags to avoid newlines that broke the markdown table format.

Last I noticed missing parenthesis after the "description" item, causing the reference to the function appear instead of the returned value.

I hope you will find these suggestions useful.