### PR TITLE
Make jinja2 env configurable

### DIFF
--- a/ontospy/gendocs/jinja_env.py
+++ b/ontospy/gendocs/jinja_env.py
@@ -60,7 +60,7 @@ def d3_dendogram_height_filter(tot_objects):
     else:
         return n
     
-def add_default_filters(env: Environment):
+def add_default_filters(env):
     env.filters['slugify'] = slugify_filter
     env.filters['linebreaks'] = linebreaks_filter
     env.filters['capfirst'] = capfirst_filter

--- a/ontospy/gendocs/jinja_env.py
+++ b/ontospy/gendocs/jinja_env.py
@@ -5,37 +5,11 @@ from markupsafe import Markup, escape
 from jinja2 import pass_eval_context
 from ontospy.core.utils import slugify
 
-#
-# SET UP JINJA2
-#
-env = Environment(
-    loader=PackageLoader('ontospy.gendocs.media', 'templates'),
-    autoescape=select_autoescape(['html', 'xml']),
-    extensions=['jinja2_time.TimeExtension']
-)
-
-
-#############################
-####### JINJA2 CUSTOM FILTERS
-###
-
-
-#
-# FILTER
-#
+_paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
 
 def slugify_filter(value):
     """A filter for legacy django templates to call that returns a slugified value."""
     return slugify(value)  # from ontospy.core.utils
-
-env.filters['slugify'] = slugify_filter
-
-
-#
-# FILTER
-#
-
-_paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
 
 @pass_eval_context
 def linebreaks_filter(eval_ctx, value):
@@ -51,12 +25,6 @@ def linebreaks_filter(eval_ctx, value):
     except:
         return value
 
-env.filters['linebreaks'] = linebreaks_filter
-
-#
-# FILTER
-#
-
 
 def capfirst_filter(value):
     """A filter for legacy django templates to call that returns a capitalized value."""
@@ -65,14 +33,6 @@ def capfirst_filter(value):
     except:
         return value
 
-env.filters['capfirst'] = capfirst_filter
-
-
-
-#
-# FILTER
-#
-
 
 def add_filter(value, integer_n):
     """A filter for legacy django templates."""
@@ -80,14 +40,6 @@ def add_filter(value, integer_n):
         return value + integer_n
     except:
         return value
-
-env.filters['add'] = add_filter
-
-
-
-#
-# FILTER
-#
 
 
 def truncatewords_filter(data, l=20):
@@ -100,16 +52,6 @@ def truncatewords_filter(data, l=20):
         return data
 
 
-env.filters['truncatewords'] = truncatewords_filter
-
-
-
-
-#
-# FILTER
-#
-
-
 def d3_dendogram_height_filter(tot_objects):
     """A filter to generate dynamically the min height of a dendogram."""
     n = 50 * tot_objects
@@ -117,7 +59,27 @@ def d3_dendogram_height_filter(tot_objects):
         return 800
     else:
         return n
+    
+def add_default_filters(env: Environment):
+    env.filters['slugify'] = slugify_filter
+    env.filters['linebreaks'] = linebreaks_filter
+    env.filters['capfirst'] = capfirst_filter
+    env.filters['add'] = add_filter
+    env.filters['truncatewords'] = truncatewords_filter
+    env.filters['d3_dendogram_height'] = d3_dendogram_height_filter
 
+def get_default_env():
+    # Setup Jinja2
+    env = Environment(
+        loader=PackageLoader('ontospy.gendocs.media', 'templates'),
+        autoescape=select_autoescape(['html', 'xml']),
+        extensions=['jinja2_time.TimeExtension']
+    )
 
-env.filters['d3_dendogram_height'] = d3_dendogram_height_filter
+    # Add custom filters
+    add_default_filters(env)
 
+    return env
+
+# Create this global variable for backwards compatibility
+env = get_default_env()

--- a/ontospy/gendocs/viz/viz_d3bar_hierarchy.py
+++ b/ontospy/gendocs/viz/viz_d3bar_hierarchy.py
@@ -19,11 +19,11 @@ class Dataviz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/d3-v3", "libs/jquery"]
 
     def _buildTemplates(self):

--- a/ontospy/gendocs/viz/viz_d3bubble_chart.py
+++ b/ontospy/gendocs/viz/viz_d3bubble_chart.py
@@ -19,11 +19,11 @@ class Dataviz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/d3-v3", "libs/jquery"]
 
     def _buildTemplates(self):

--- a/ontospy/gendocs/viz/viz_d3dendogram.py
+++ b/ontospy/gendocs/viz/viz_d3dendogram.py
@@ -20,11 +20,11 @@ class Dataviz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/d3-v2", "libs/jquery"]
 
     def _buildTemplates(self):

--- a/ontospy/gendocs/viz/viz_d3pack_hierarchy.py
+++ b/ontospy/gendocs/viz/viz_d3pack_hierarchy.py
@@ -20,11 +20,11 @@ class Dataviz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/d3-v3", "libs/jquery"]
 
     def _buildTemplates(self):

--- a/ontospy/gendocs/viz/viz_d3partition_table.py
+++ b/ontospy/gendocs/viz/viz_d3partition_table.py
@@ -19,11 +19,11 @@ class Dataviz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/d3-v3", "libs/jquery"]
 
     def _buildTemplates(self):

--- a/ontospy/gendocs/viz/viz_d3rotating_cluster.py
+++ b/ontospy/gendocs/viz/viz_d3rotating_cluster.py
@@ -21,11 +21,11 @@ class Dataviz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/d3-v3", "libs/jquery"]
 
     def _buildTemplates(self):

--- a/ontospy/gendocs/viz/viz_html_multi.py
+++ b/ontospy/gendocs/viz/viz_html_multi.py
@@ -39,11 +39,11 @@ class KompleteViz(VizFactory):
     """
 
 
-    def __init__(self, ontospy_graph, title="", theme=""):
+    def __init__(self, ontospy_graph, title="", theme="", *args, **kwargs):
         """
         Init
         """
-        super(KompleteViz, self).__init__(ontospy_graph, title)
+        super(KompleteViz, self).__init__(ontospy_graph, title, *args, **kwargs)
         self.static_files = [
                 "custom",
                 "libs/bootswatch3_2",

--- a/ontospy/gendocs/viz/viz_html_single.py
+++ b/ontospy/gendocs/viz/viz_html_single.py
@@ -18,11 +18,11 @@ class HTMLVisualizer(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(HTMLVisualizer, self).__init__(ontospy_graph, title)
+        super(HTMLVisualizer, self).__init__(*args, **kwargs)
         self.template_name = "html-single/html-single.html"
         self.main_file_name = "index.html"
 

--- a/ontospy/gendocs/viz/viz_markdown.py
+++ b/ontospy/gendocs/viz/viz_markdown.py
@@ -19,11 +19,11 @@ class MarkdownViz(VizFactory):
 
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(MarkdownViz, self).__init__(ontospy_graph, title)
+        super(MarkdownViz, self).__init__(*args, **kwargs)
 
     def _buildTemplates(self):
         """

--- a/ontospy/gendocs/viz/viz_sigmajs.py
+++ b/ontospy/gendocs/viz/viz_sigmajs.py
@@ -25,11 +25,11 @@ class Dataviz(VizFactory):
     """
 
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, *args, **kwargs):
         """
         Init
         """
-        super(Dataviz, self).__init__(ontospy_graph, title)
+        super(Dataviz, self).__init__(*args, **kwargs)
         self.static_files = ["libs/sigma", "libs/jquery"]
 
 

--- a/ontospy/gendocs/viz_factory.py
+++ b/ontospy/gendocs/viz_factory.py
@@ -5,9 +5,10 @@
 
 from .. import * # import main ontospy VERSION 
 from ..core.utils import *  
-from .actions import ONTODOCS_VIZ_TEMPLATES, ONTODOCS_VIZ_STATIC
+from .actions import ONTODOCS_VIZ_STATIC
 from .utils import *
-from .jinja_env import *
+from .jinja_env import get_default_env
+from jinja2 import Environment
 
 import zipfile
 import os
@@ -32,7 +33,7 @@ class VizFactory(object):
     Tip: subclass and override as needed.
     """
 
-    def __init__(self, ontospy_graph, title=""):
+    def __init__(self, ontospy_graph, title="", jinja2env: Environment = None):
         self.title = ''
         self.ontospy_graph = ontospy_graph
         self.static_files = []
@@ -44,10 +45,10 @@ class VizFactory(object):
         self.output_path_DEFAULT = os.path.join(home, "ontospy-viz")
         self.template_name = ""
         self.main_file_name = ""
-        self.templates_root = ONTODOCS_VIZ_TEMPLATES
         self.static_root = ONTODOCS_VIZ_STATIC
         self.title = title or self.infer_best_title()
         self.basic_context_data = self._build_basic_context()
+        self.jinja2env = jinja2env or get_default_env()
 
     def infer_best_title(self):
         """Selects something usable as a title for an ontospy graph. 
@@ -97,8 +98,7 @@ class VizFactory(object):
         :param extraContext: a dict that can be loaded on demand
         :return: the rendered template as a string
         """
-        # t = env.get_template(self.templates_root + template_name)  # FAILS
-        t = env.get_template(template_name)
+        t = self.jinja2env.get_template(template_name)
         context = self.basic_context_data
         if extraContext and type(extraContext) == dict:
             context.update(extraContext)

--- a/ontospy/gendocs/viz_factory.py
+++ b/ontospy/gendocs/viz_factory.py
@@ -8,7 +8,6 @@ from ..core.utils import *
 from .actions import ONTODOCS_VIZ_STATIC
 from .utils import *
 from .jinja_env import get_default_env
-from jinja2 import Environment
 
 import zipfile
 import os
@@ -33,7 +32,7 @@ class VizFactory(object):
     Tip: subclass and override as needed.
     """
 
-    def __init__(self, ontospy_graph, title="", jinja2env: Environment = None):
+    def __init__(self, ontospy_graph, title="", jinja2env = None):
         self.title = ''
         self.ontospy_graph = ontospy_graph
         self.static_files = []


### PR DESCRIPTION
**Feature**: `VizFactory` can take the jinja2 environment from outside (fallbacks to the same default it was before)

With this change, users can override the templates used for the different visualizers. Example:

```python
import ontospy
from ontospy.gendocs.viz.viz_html_single import *
from ontospy.gendocs.jinja_env import add_default_filters
from jinja2 import Environment, PackageLoader, select_autoescape, ChoiceLoader

g = ontospy.Ontospy("http://cohere.open.ac.uk/ontology/cohere.owl#")

# Provide my jinja2 environment so I can override some templates
my_environment = Environment(
    loader=ChoiceLoader(
        [
            FileSystemLoader(["/override/templates"]),
            PackageLoader("ontospy.gendocs.media", "templates"),
        ]
    ),
    autoescape=select_autoescape(["html", "xml"]),
    extensions=["jinja2_time.TimeExtension"],
)
add_default_filters(my_environment)

v = HTMLVisualizer(g, jinja2env=my_environment) # => instantiate the visualization object
v.build() # => render visualization. You can pass an 'output_path' parameter too
v.preview() # => open in browser
```

---

**Personal note.-** I plan to use the _gendocs_ capability (`html_multi`) for one of my projects (I really like the output!). I would like to contribute to the project. Besides the contributions I would love to do around the template framework, I can help updating the codebase (https://github.com/lambdamusic/Ontospy/issues/129) or improving the testing.
